### PR TITLE
Methods for managing cell specific classes

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -302,6 +302,7 @@ if (!jQuery.fn.drag) {
         var selectedRowsLookup = {};
         var columnsById = {};
         var highlightedCells;
+        var cellClasses;
         var sortColumnId;
         var sortAsc = true;
 
@@ -1196,6 +1197,10 @@ if (!jQuery.fn.drag) {
                 var m = columns[i];
 
                 cellCss = "slick-cell c" + i + (m.cssClass ? " " + m.cssClass : "");
+                
+                if (cellClasses && cellClasses[row] && cellClasses[row][m.id])
+                    cellCss += (" " + cellClasses[row][m.id]);
+
                 if (highlightedCells && highlightedCells[row] && highlightedCells[row][m.id])
                     cellCss += (" " + options.cellHighlightCssClass);
 
@@ -1603,6 +1608,56 @@ if (!jQuery.fn.drag) {
             }
         }
 
+        function addCellClass(row, col, cls) {
+            if (typeof col == 'number')
+                col = columns[col].id;
+            
+            if (!cellClasses)
+                cellClasses = {};
+            
+            if (!cellClasses[row])
+                cellClasses[row] = {};
+            
+            if (!cellClasses[row][col])
+                cellClasses[row][col] = "";
+            
+            var classNames = cellClasses[row][col];
+            classNames = classNames.replace(" "+cls, "");
+            classNames += " "+cls;
+            cellClasses[row][col] = classNames;
+
+            if (rowsCache[row]) {
+                var $cell = $(rowsCache[row]).children().eq(getColumnIndex(col));
+                if ($cell.length) {
+                    $cell.addClass(cls)
+                }
+            }
+        }
+
+        function removeCellClass(row, col, cls) {
+            if (typeof col == 'number')
+                col = columns[col].id;
+            
+            if (!cellClasses)
+                cellClasses = {};
+                
+            if (!cellClasses[row])
+                return
+            if (!cellClasses[row][col])
+                return
+                
+            var classNames = cellClasses[row][col];
+            classNames = classNames.replace(" "+cls, "");
+            cellClasses[row][col] = classNames;
+            
+            if (rowsCache[row]) {
+                var $cell = $(rowsCache[row]).children().eq(getColumnIndex(col));
+                if ($cell.length) {
+                    $cell.removeClass(cls)
+                }
+            }
+        }
+        
         //////////////////////////////////////////////////////////////////////////////////////////////
         // Interactivity
 
@@ -2453,6 +2508,8 @@ if (!jQuery.fn.drag) {
             "invalidate":          invalidate,
             "setHighlightedCells": setHighlightedCells,
             "flashCell":           flashCell,
+            "addCellClass":        addCellClass,
+            "removeCellClass":     removeCellClass,
             "getViewport":         getVisibleRange,
             "resizeCanvas":        resizeCanvas,
             "updateRowCount":      updateRowCount,


### PR DESCRIPTION
Added in methods that allow adding and removing css classes to specific cells. 

The implementation is proof of concept and could most likely be cleaned up. This could also have implications on performance if abused, but for most usage seems appropriate as it is an extension of the setHighlightedCells functionality. 

Methods exposed via API:
    addCellClass(row, col, cls)
    removeCellClass(row, col, cls)

Useful when setHighlightedCells is not enough control and you don't want to hack in a div or span just to get custom classes on the cell. For example, when flushing changes to a backend server:

```
grid.onCellChange = function(row, col, item) {
    grid.addCellClass(row, col, "dirty");
    post({
        success: function(result) {
             grid.removeCellClass(row, col, "dirty");
        },
        error: function(result) {
             grid.removeCellClass(row, col, "dirty");
             grid.addCellClass(row, col, "error");
        }
    });
}
```
