### PR TITLE
Check if the SlickGrid container exists.

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -172,6 +172,9 @@ if (typeof Slick === "undefined") {
             /// </summary>
 
             $container = $(container);
+            if($container.length < 1) {
+              throw new Error("SlickGrid requires a valid container, "+container+" does not exist in the DOM.");
+            }
 
             maxSupportedCssHeight = getMaxSupportedCssHeight();
 


### PR DESCRIPTION
I added the validation for the SlickGrid container. I had an issue where I misspelled my container name and was getting a jQuery error:

```
Cannot read property 'offsetWidth' of undefined
```

It now throws the following error:

```
 SlickGrid requires a valid container, [container_name] does not exist in the DOM.
```
