### PR TITLE
Added excludedColumns option to slick.columnpicker.js

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -1,90 +1,115 @@
 (function($) {
-	function SlickColumnPicker(columns,grid,options)
-	{
-		var $menu;
+    function SlickColumnPicker(columns,grid,options)
+    {
+        var $menu;
 
-		var defaults = {
-			fadeSpeed: 250
-		};
+        var defaults = {
+            fadeSpeed: 250,
+            excludedColumns: []
+        };
 
-		function init() {
-			grid.onHeaderContextMenu.subscribe(handleHeaderContextMenu);
-			options = $.extend({}, defaults, options);
+        function init() {
+            grid.onHeaderContextMenu.subscribe(handleHeaderContextMenu);
+            options = $.extend({}, defaults, options);
 
-			$menu = $("<span class='slick-columnpicker' style='display:none;position:absolute;z-index:20;' />").appendTo(document.body);
+            $menu = $("<span class='slick-columnpicker' style='display:none;position:absolute;z-index:20;' />").appendTo(document.body);
 
-			$menu.bind("mouseleave", function(e) { $(this).fadeOut(options.fadeSpeed) });
-			$menu.bind("click", updateColumn);
+            $menu.bind("mouseleave", function(e) { $(this).fadeOut(options.fadeSpeed) });
+            $menu.bind("click", updateColumn);
 
-		}
+        }
 
-		function handleHeaderContextMenu(e, args)
-		{
+        function excludeColumnCheck(column) {
+            var exclude = false; //assume it's not excluded
+            for (var i in options.excludedColumns){
+                if (options.excludedColumns.propertyIsEnumerable(i)){
+                    if (options.excludedColumns[i].id == column.id){
+                        exclude = true;
+                    }
+                }
+            }
+            return exclude;
+        }
+
+        function columnsShownInMenu() {
+            var shown_columns = [];
+            for (var i in columns){
+                if (columns.propertyIsEnumerable(i)){
+                    if(!excludeColumnCheck(columns[i])){
+                        shown_columns.push(columns[i]);
+                    }
+                }
+            }
+            return shown_columns;
+        }
+
+        function handleHeaderContextMenu(e, args)
+        {
             e.preventDefault();
-			$menu.empty();
+            $menu.empty();
+            var $li, $input;
+            var columns_shown_in_menu = columnsShownInMenu();
+            for (var i=0; i<columns_shown_in_menu.length; i++) {
+                $li = $("<li />").appendTo($menu);
 
-			var $li, $input;
-			for (var i=0; i<columns.length; i++) {
-				$li = $("<li />").appendTo($menu);
-
-				$input = $("<input type='checkbox' />")
+                $input = $("<input type='checkbox' />")
                         .attr("id", "columnpicker_" + i)
-                        .data("id", columns[i].id)
+                        .data("id", columns_shown_in_menu[i].id)
                         .appendTo($li);
 
-                if (grid.getColumnIndex(columns[i].id) != null)
+                if (grid.getColumnIndex(columns_shown_in_menu[i].id) != null)
                     $input.attr("checked","checked");
 
-				$("<label for='columnpicker_" + i + "' />")
-					.text(columns[i].name)
-					.appendTo($li);
-			}
+                $("<label for='columnpicker_" + i + "' />")
+                        .text(columns_shown_in_menu[i].name)
+                        .appendTo($li);
+            }
 
-			$("<hr/>").appendTo($menu);
-			$li = $("<li />").appendTo($menu);
-			$input = $("<input type='checkbox' id='autoresize' />").appendTo($li);
-			$("<label for='autoresize'>Force Fit Columns</label>").appendTo($li);
-			if (grid.getOptions().forceFitColumns)
-				$input.attr("checked", "checked");
+            $("<hr/>").appendTo($menu);
+            $li = $("<li />").appendTo($menu);
+            $input = $("<input type='checkbox' id='autoresize' />").appendTo($li);
+            $("<label for='autoresize'>Force Fit Columns</label>").appendTo($li);
+            if (grid.getOptions().forceFitColumns)
+                $input.attr("checked", "checked");
 
-			$li = $("<li />").appendTo($menu);
-			$input = $("<input type='checkbox' id='syncresize' />").appendTo($li);
-			$("<label for='syncresize'>Synchronous Resizing</label>").appendTo($li);
-			if (grid.getOptions().syncColumnCellResize)
-				$input.attr("checked", "checked");
+            $li = $("<li />").appendTo($menu);
+            $input = $("<input type='checkbox' id='syncresize' />").appendTo($li);
+            $("<label for='syncresize'>Synchronous Resizing</label>").appendTo($li);
+            if (grid.getOptions().syncColumnCellResize)
+                $input.attr("checked", "checked");
 
-			$menu
-				.css("top", e.pageY - 10)
-				.css("left", e.pageX - 10)
-				.fadeIn(options.fadeSpeed);
-		}
+            $menu
+                    .css("top", e.pageY - 10)
+                    .css("left", e.pageX - 10)
+                    .fadeIn(options.fadeSpeed);
+        }
 
-		function updateColumn(e)
-		{
-			if (e.target.id == 'autoresize') {
-				if (e.target.checked) {
-					grid.setOptions({forceFitColumns: true});
-					grid.autosizeColumns();
-				} else {
-					grid.setOptions({forceFitColumns: false});
-				}
-				return;
-			}
+        function updateColumn(e)
+        {
+            if (e.target.id == 'autoresize') {
+                if (e.target.checked) {
+                    grid.setOptions({forceFitColumns: true});
+                    grid.autosizeColumns();
+                } else {
+                    grid.setOptions({forceFitColumns: false});
+                }
+                return;
+            }
 
-			if (e.target.id == 'syncresize') {
-				if (e.target.checked) {
-					grid.setOptions({syncColumnCellResize: true});
-				} else {
-					grid.setOptions({syncColumnCellResize: false});
-				}
-				return;
-			}
+            if (e.target.id == 'syncresize') {
+                if (e.target.checked) {
+                    grid.setOptions({syncColumnCellResize: true});
+                } else {
+                    grid.setOptions({syncColumnCellResize: false});
+                }
+                return;
+            }
 
-			if ($(e.target).is(":checkbox")) {
-				if ($menu.find(":checkbox:checked").length == 0) {
-					$(e.target).attr("checked","checked");
-					return;
-				}
+            if ($(e.target).is(":checkbox")) {
+                if ($menu.find(":checkbox:checked").length == 0) {
+                    $(e.target).attr("checked","checked");
+                    return;
+                }
 
                 var visibleColumns = [];
                 $menu.find(":checkbox[id^=columnpicker]").each(function(i,e) {
@@ -93,13 +118,13 @@
                     }
                 });
                 grid.setColumns(visibleColumns);
-			}
-		}
+            }
+        }
 
 
-		init();
-	}
+        init();
+    }
 
-	// Slick.Controls.ColumnPicker
-	$.extend(true, window, { Slick: { Controls: { ColumnPicker: SlickColumnPicker }}});
+    // Slick.Controls.ColumnPicker
+    $.extend(true, window, { Slick: { Controls: { ColumnPicker: SlickColumnPicker }}});
 })(jQuery);


### PR DESCRIPTION
Helpful when columnpicker used with checkboxselectcolumn plugin.  Example usage:

```
    var grid;

    var columns = [];

    var checkboxSelector = new Slick.CheckboxSelectColumn({
        cssClass: "slick-cell-checkboxsel"
    });
    var checkbox_column = checkboxSelector.getColumnDefinition();
    columns.push(checkbox_column);

    var headers = <%= raw Slickgrid::ColumnExtractor.from_data(@lands).to_json %>;
    for (var i in headers) if (headers.propertyIsEnumerable(i)) columns.push(headers[i]);

    var columnpicker_options = {
        excludedColumns: [checkbox_column]
    }

    $(function() {
        grid = new Slick.Grid("#myGrid", data, columns, grid_options);
        var columnpicker = new Slick.Controls.ColumnPicker(columns, grid, columnpicker_options);
        grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow:false}));
        grid.registerPlugin(checkboxSelector);
        $("#myGrid").show();
    })
```
