### PR TITLE
Fix to arrow key navigation bounds when using autoedit

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1574,6 +1574,7 @@ if (typeof Slick === "undefined") {
 
             if (!handled) {
                 if (!e.shiftKey && !e.altKey && !e.ctrlKey) {
+                    var activeCell = self.getActiveCell();
                     if (e.which == 27) {
                         if (!getEditorLock().isActive()) {
                             return; // no editing mode to cancel, allow bubbling and default processing (exit without cancelling the event)
@@ -1581,23 +1582,26 @@ if (typeof Slick === "undefined") {
                         cancelEditAndSetFocus();
                     }
                     else if (e.which == 37) {
-                        navigateLeft();
+                        if (activeCell.cell != 0) navigateLeft();
                     }
                     else if (e.which == 39) {
-                        navigateRight();
+                        var cellCount = self.getColumns().length;
+                        if (activeCell.cell != cellCount - 1) navigateRight();
                     }
                     else if (e.which == 38) {
-                        navigateUp();
+                        if (activeCell.row != 0) navigateUp();
                     }
                     else if (e.which == 40) {
-                        navigateDown();
+                        var rowCount = self.getDataLength();
+                        if (activeCell.row != rowCount - 1) navigateDown();
                     }
                     else if (e.which == 9) {
-                        navigateNext();
+                        var cellCount = self.getColumns().length;
+                        if (activeCell.cell != cellCount - 1) navigateNext();
                     }
                     else if (e.which == 13) {
                         if (options.editable) {
-                            if (currentEditor) {
+                             if (currentEditor) {
                                 // adding new row
                                 if (activeRow === getDataLength()) {
                                     navigateDown();


### PR DESCRIPTION
Wrote a small patch for the following issue:

When you are have autoedit on and click the up arrow key while the top row is selected, you lose the ability to keep navigating on the grid with arrow keys. A similar problem occurs on the other bounds of the grid.

Issue is confirmed on an example: http://mleibman.github.com/SlickGrid/examples/example3-editing.html
And reported here: https://github.com/mleibman/SlickGrid/issues/176
