### PR TITLE
Fix bug using slick.checkboxselectioncolumn and columnpicker together

### DIFF
--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -80,6 +80,11 @@
         }
 
         function handleHeaderClick(e, args) {
+            // No cloumn was clicked, but instead the background of header
+            if (args.column == undefined) {
+                return;
+            }
+            
             if (args.column.id == _options.columnId && $(e.target).is(":checkbox")) {
                 // if editing, try to commit
                 if (_grid.getEditorLock().isActive() && !_grid.getEditorLock().commitCurrentEdit()) {


### PR DESCRIPTION
Using slick.checkboxselectioncolumn and columnpicker together and
clicking on the area for columnpicker, firebug writes out
following error and the event propagation stops:

args.column is undefined
.../javascripts/vendor/slick.plugins/slick.checkboxselectcolumn.js
Line 83

Since it is possible to have an onHeader event without a column by
clicking on background aerea, the event handler should take care of this.

This bug was reproduced with Firefox 3 & 4.
