### PR TITLE
Fixed dataview filtering breaking, after compressing JS with e.g. Google Closure Compiler

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -428,18 +428,20 @@
                 .replace(/return ([^;]+?);/gi,
                     "{ if ($1) { _retval[_idx++] = $item$; }; continue _coreloop; }");
 
-            var fnTemplate = function(_items, _args) {
-                var _retval = [], _idx = 0;
-                var $item$, $args$ = _args;
-                _coreloop:
-                for (var _i = 0, _il = _items.length; _i < _il; _i++) {
-                    $item$ = _items[_i];
-                    $filter$;
-                }
-                return _retval;
-            };
-
-            var tpl = getFunctionInfo(fnTemplate).body;
+            // This preserves the function template code after JS compression,
+            // so that replace() commands still work as expected.
+            var tpl = [
+                //"function(_items, _args) { ",
+                    "var _retval = [], _idx = 0; ",
+                    "var $item$, $args$ = _args; ",
+                    "_coreloop: ",
+                    "for (var _i = 0, _il = _items.length; _i < _il; _i++) { ",
+                        "$item$ = _items[_i]; ",
+                        "$filter$; ",
+                    "} ",
+                    "return _retval; "
+                //"}"
+            ].join("");
             tpl = tpl.replace(/\$filter\$/gi, filterBody);
             tpl = tpl.replace(/\$item\$/gi, filterInfo.params[0]);
             tpl = tpl.replace(/\$args\$/gi, filterInfo.params[1]);
@@ -458,22 +460,24 @@
                 .replace(/return ([^;]+?);/gi,
                     "{ if ((_cache[_i] = $1)) { _retval[_idx++] = $item$; }; continue _coreloop; }");
 
-            var fnTemplate = function(_items, _args, _cache) {
-                var _retval = [], _idx = 0;
-                var $item$, $args$ = _args;
-                _coreloop:
-                for (var _i = 0, _il = _items.length; _i < _il; _i++) {
-                    $item$ = _items[_i];
-                    if (_cache[_i]) {
-                        _retval[_idx++] = $item$;
-                        continue _coreloop;
-                    }
-                    $filter$;
-                }
-                return _retval;
-            };
-
-            var tpl = getFunctionInfo(fnTemplate).body;
+            // This preserves the function template code after JS compression,
+            // so that replace() commands still work as expected.
+            var tpl = [
+                //"function(_items, _args, _cache) { ",
+                    "var _retval = [], _idx = 0; ",
+                    "var $item$, $args$ = _args; ",
+                    "_coreloop: ",
+                    "for (var _i = 0, _il = _items.length; _i < _il; _i++) { ",
+                        "$item$ = _items[_i]; ",
+                        "if (_cache[_i]) { ",
+                            "_retval[_idx++] = $item$; ",
+                            "continue _coreloop; ",
+                        "} ",
+                        "$filter$; ",
+                    "} ",
+                    "return _retval; "
+                //"}"
+            ].join("");
             tpl = tpl.replace(/\$filter\$/gi, filterBody);
             tpl = tpl.replace(/\$item\$/gi, filterInfo.params[0]);
             tpl = tpl.replace(/\$args\$/gi, filterInfo.params[1]);


### PR DESCRIPTION
### Background

We're using SlickGrid (it's _awesome_), and recently updated to latest. We found that after running our build scripts, which compress our JS files using Google Closure Compiler, our grids that used DataView filtering all broke.
### Cause

The problem is with the general approach that SlickGrid.DataView's `compileFilter()` and `compileFilterWithCaching()` use; that is, using `Function.toString()` to fetch original source code for `fnTemplate` and the user's filter function, to generate a new function. 

The code relies on carefully named variables to act as targets for later string replacement. These will be shortened/changed by compressors, so the behavior ends up broken.

(The code also makes some pretty strong expectations about the style/structure of the user's filter function, which causes other issues... I will elaborate in a separate issue)
### Fix

To fix, I rewrote the function templates as strings, since it's only there so that the function body can be retrieved via `Function.toString()`. This prevents them from being modified by a JS compressor. Unfortunately, the readability is penalised a little bit.

Furthermore, there isn't any workaround offered by Google Closure Compiler; there is no way to ignore or "not-compress" the code, whether at the function level or at the file level.

I hope this saves someone else hours of debugging...
