### PR TITLE
move new style blocks from head to $container

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -706,7 +706,7 @@ if (typeof Slick === "undefined") {
         }
 
         function createCssRules() {
-            $style = $("<style type='text/css' rel='stylesheet' />").appendTo($("head"));
+            $style = $("<style type='text/css' rel='stylesheet' />").appendTo($container);
             var rowHeight = (options.rowHeight - cellHeightDiff);
 
             var rules = [


### PR DESCRIPTION
add new style blocks to container instead of head so that if destroy is not called, there is no memory leak and IE8 does not explode from too many style blocks
