### PR TITLE
Include the missing "e" argument in onSort event generation.

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -481,7 +481,7 @@ if (typeof Slick === "undefined") {
                     }
 
                     setSortColumn(sortColumnId,sortAsc);
-                    trigger(self.onSort, {sortCol:column,sortAsc:sortAsc});
+                    trigger(self.onSort, {sortCol:column,sortAsc:sortAsc}, e);
                 }
             });
         }


### PR DESCRIPTION
It is useful if we need to check the ctrlKey or shiftKey fields
when the user clicks a column header.

Signed-off-by: David Capello davidcapello@gmail.com
