### PR TITLE
minor bug fix to autosizeColumns()

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -804,7 +804,8 @@ if (typeof Slick === "undefined") {
             var i, c,
                 widths = [],
                 shrinkLeeway = 0,
-                availWidth = (options.autoHeight ? viewportW : viewportW - scrollbarDimensions.width), // with AutoHeight, we do not need to accomodate the vertical scroll bar
+                containerW = parseFloat($.css($container[0], "width", true)), // get current width - resizeCanvas below will reset viewport 
+                availWidth = (options.autoHeight ? containerW : containerW - scrollbarDimensions.width), // with AutoHeight, we do not need to accomodate the vertical scroll bar
                 total = 0,
                 existingTotal = 0;
 


### PR DESCRIPTION
on a resize, autosizeColumns uses the last saved width (viewportW ) rather than the new width. the global width is updated after the header width calcs are done.

note: this is the first time I've used github, so hopefully I've done the pull request correct.
