### PR TITLE
Don't use undefined global variable "columns" in markCopySelection() of the CellCopyManager

### DIFF
--- a/plugins/slick.cellcopymanager.js
+++ b/plugins/slick.cellcopymanager.js
@@ -56,6 +56,7 @@
         }
 
         function markCopySelection(ranges) {
+            var columns = _grid.getColumns();
             var hash = {};
             for (var i = 0; i < ranges.length; i++) {
                 for (var j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {


### PR DESCRIPTION
The function markCopySelection() inside CellCopyManager() is using the "columns" global variable instead of getting the columns from the grid. Currently it only works because the example (e.g. example-spreadsheet.html) defines this global variable.
