### PR TITLE
Convert some stray [] accesses to the field accessor interface.

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1872,7 +1872,7 @@ if (typeof Slick === "undefined") {
             currentEditor = null;
 
             if (activeCellNode) {
-		var d = getDataItem(activeRow);
+                var d = getDataItem(activeRow);
 
                 $(activeCellNode).removeClass("editable invalid");
 


### PR DESCRIPTION
The commit in this pull request converts some bracket accesses in `slick.grid.js` to `getDataItemValueForColumn` invocations.  See https://github.com/mleibman/SlickGrid/pull/221#issuecomment-3137162.
