### PR TITLE
added support for parameter less functions as fields

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1072,7 +1072,15 @@ if (typeof Slick === "undefined") {
             if (options.dataItemColumnValueExtractor) {
                 return options.dataItemColumnValueExtractor(item, columnDef);
             }
-            return item[columnDef.field];
+            
+            var value = item[columnDef.field];
+            //check if value is a function
+            // Pure duck-typing implementation taken from Underscore.js.
+            if(!!(value && value.constructor && value.call && value.apply)) {
+                return value(); //if so invoke it
+            }
+
+            return value;
         }
 
         function appendRowHtml(stringArray, row) {


### PR DESCRIPTION
I hope you find this idea interesting. Just to make an example where this could be usefull is knockout observables. Actually the grid don't support it, at least not without specifing a dataItemColumnValueExtractor.
I think this is a really small change but really usefull. I looked for the fastest "function test", but if you have another one you can change it.
