### PR TITLE
Made it possible to configure idProperty in DataView (small change)

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -23,12 +23,12 @@
     var self = this;
 
     var defaults = {
+      idProperty: 'id',
       groupItemMetadataProvider: null
     };
 
 
     // private
-    var idProperty = "id";  // property holding a unique row id
     var items = [];         // data by index
     var rows = [];          // data by row
     var idxById = {};       // indexes by id
@@ -68,6 +68,7 @@
     var onPagingInfoChanged = new Slick.Event();
 
     options = $.extend(true, {}, defaults, options);
+    var idProperty = options.idProperty;  // property holding a unique row id
 
 
     function beginUpdate() {


### PR DESCRIPTION
Hi 

Happy SlickGrid user here :-)

This small patch to slick.dataview,js makes idProperty configurable. This saves us a lot of time renaming the key in all our data structures. 
## 

Tore Bastiansen
