### PR TITLE
Multi column sort support with an example

### DIFF
--- a/examples/example-multi-column-sort.html
+++ b/examples/example-multi-column-sort.html
@@ -1,0 +1,95 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <title>SlickGrid example: Multi Column Sort</title>
+  <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
+  <link rel="stylesheet" href="../css/smoothness/jquery-ui-1.8.16.custom.css" type="text/css"/>
+  <link rel="stylesheet" href="examples.css" type="text/css"/>
+</head>
+<body>
+<table width="100%">
+  <tr>
+    <td valign="top" width="50%">
+      <div id="myGrid" style="width:600px;height:500px;display:none;"></div>
+    </td>
+    <td valign="top">
+      <h2>Demonstrates:</h2>
+      <ul>
+        <li>basic grid with multi column sort option</li>
+      </ul>
+    </td>
+  </tr>
+</table>
+
+<script src="../lib/jquery-1.7.min.js"></script>
+<script src="../lib/jquery.event.drag-2.0.min.js"></script>
+
+<script src="../slick.core.js"></script>
+<script src="../slick.grid.js"></script>
+
+<script>
+  var grid;
+  var columns = [
+    { id: "title", name: "Title", field: "title", sortable: true },
+    { id: "duration", name: "Duration", field: "duration", sortable: true, formatter: dayFormatter },
+    { id: "%", name: "% Complete", field: "percentComplete", sortable: true },
+    { id: "start", name: "Start", field: "start", formatter: dateFormatter, sortable: true },
+    { id: "finish", name: "Finish", field: "finish", formatter: dateFormatter, sortable: true },
+    { id: "effort-driven", name: "Effort Driven", field: "effortDriven", sortable: true }
+  ];
+
+  function dayFormatter(row, cell, value, columnDef, dataContext) {
+      return value + ' days';
+  }
+
+  function dateFormatter(row, cell, value, columnDef, dataContext) {
+      return value.getMonth() + '/' + value.getDate() + '/' + value.getFullYear();
+  }
+
+  var options = {
+    enableCellNavigation: true,
+    enableColumnReorder: false,
+    multiSort: true
+  };
+
+  $(function () {
+    var data = [];
+    for (var i = 0; i < 500; i++) {
+      var startdate = new Date(new Date("1/1/1980").getTime() + Math.round(Math.random() * 365 * 25)*24*60*60*1000);
+      var endDate = new Date(startdate.getTime() + Math.round(Math.random() * 365) * 24 * 60 * 60 * 1000);
+      data[i] = {
+        title: "Task " + i,
+        duration: Math.round(Math.random() * 30) + 2,
+        percentComplete: Math.round(Math.random() * 100),
+        start: startdate,
+        finish: endDate,
+        effortDriven: (i % 5 == 0)
+      };
+    }
+
+    grid = new Slick.Grid("#myGrid", data, columns, options);
+
+    grid.onSort.subscribe(function (e, cols) {
+      data.sort(function (dataRow1, dataRow2) {
+        for (var i = 0, l = cols.length; i < l; i++) {
+          var field = cols[i].column.field;
+          var sign = cols[i].sortAsc ? 1 : -1;
+          var value1 = dataRow1[field], value2 = dataRow2[field];
+          var result = (value1 == value2 ? 0 : (value1 > value2 ? 1 : -1)) * sign;
+          if (result != 0) {
+            return result;
+          }
+        }
+        return 0;
+      });
+      grid.setData(data);
+      grid.invalidateAllRows();
+      grid.render();
+    });
+
+    $("#myGrid").show();
+  })
+</script>
+</body>
+</html>


### PR DESCRIPTION
multiSort option been added to the grid.
When set to false (default) should work as before in compatibility mode.
When set to true onSort event will send array of objects [{column,sortAsc},...].
dataView is not touched.

The example is in examples folder with the name of example-multi-column-sort.
