### PR TITLE
Previous introduction of Multi-Column sort breaks any possible inclusion of custom sorter

### DIFF
--- a/examples/example-multi-column-sort.html
+++ b/examples/example-multi-column-sort.html
@@ -31,12 +31,12 @@
 <script>
   var grid;
   var columns = [
-    { id: "title", name: "Title", field: "title", sortable: true },
-    { id: "duration", name: "Duration", field: "duration", sortable: true, formatter: dayFormatter },
-    { id: "%", name: "% Complete", field: "percentComplete", sortable: true },
-    { id: "start", name: "Start", field: "start", formatter: dateFormatter, sortable: true },
-    { id: "finish", name: "Finish", field: "finish", formatter: dateFormatter, sortable: true },
-    { id: "effort-driven", name: "Effort Driven", field: "effortDriven", sortable: true }
+    { id: "title", name: "Title", field: "title", sortable: true, sorter: sorterStringCompare },
+    { id: "duration", name: "Duration", field: "duration", sortable: true, sorter: sorterStringCompare, formatter: dayFormatter },
+    { id: "%", name: "% Complete", field: "percentComplete", sortable: true, sorter: sorterNumeric },
+    { id: "start", name: "Start", field: "start", formatter: dateFormatter, sortable: true, sorter: sorterStringCompare },
+    { id: "finish", name: "Finish", field: "finish", formatter: dateFormatter, sortable: true, sorter: sorterStringCompare },
+    { id: "effort-driven", name: "Effort Driven", field: "effortDriven", sortable: true, sorter: sorterStringCompare }
   ];
 
   function dayFormatter(row, cell, value, columnDef, dataContext) {
@@ -46,6 +46,15 @@
   function dateFormatter(row, cell, value, columnDef, dataContext) {
       return value.getMonth() + '/' + value.getDate() + '/' + value.getFullYear();
   }
+  
+  function sorterStringCompare(a,b) {
+  	var x = a[sortcol], y = b[sortcol];
+		return sortdir * (x == y ? 0 : (x > y ? 1 : -1));
+	}
+	
+	function sorterNumeric(a, b) {
+		return sortdir *  (a[sortcol]-b[sortcol]);
+	}
 
   var options = {
     enableCellNavigation: true,
@@ -76,13 +85,13 @@
 
       data.sort(function (dataRow1, dataRow2) {
         for (var i = 0, l = cols.length; i < l; i++) {
-          var field = cols[i].sortCol.field;
-          var sign = cols[i].sortAsc ? 1 : -1;
-          var value1 = dataRow1[field], value2 = dataRow2[field];
-          var result = (value1 == value2 ? 0 : (value1 > value2 ? 1 : -1)) * sign;
-          if (result != 0) {
-            return result;
-          }
+          sortcol = cols[i].sortCol.field;
+  				sortdir = cols[i].sortAsc ? 1 : -1;
+					var value1 = dataRow1[sortcol], value2 = dataRow2[sortcol];
+					var result = args.sortCols[i].sortCol.sorter(dataRow1, dataRow2);                        
+					if (result != 0) {
+						return result;
+					}
         }
         return 0;
       });


### PR DESCRIPTION
Hey Micheal

After seeing the new code for multi-column sorting support, I decided to add it to my code and found that it breaks the possibility of adding any new custom sorter which I need and use, especially the numeric sort. 

So after spending some time, I found the solution which makes any custom sorters to work again. I thought you had some custom sorters in your examples but I must have found it somewhere else. Anyways I modified previous example code to include 2 customs sorter (sorterNumeric, sorterStringCompare) and it's working great now, well I mean you might not see the difference in that example but in my data grid 20 was bigger than 1500 since in a String compare 2 is bigger than 1...which is not exactly what I wanted so... 

Let me know if it's as you want, or if you want another example file created for that purpose... :)
