### PR TITLE
CSS changes to prevent ellipsis shown in Firefox instead of column headers

### DIFF
--- a/slick.grid.css
+++ b/slick.grid.css
@@ -27,7 +27,7 @@ classes should alter those!
   height: 16px;
   line-height: 16px;
   margin: 0;
-  padding: 4px;
+  padding: 2px;
   border-right: 1px solid silver;
   border-left: 0px;
   border-top: 0px;
@@ -36,7 +36,7 @@ classes should alter those!
 }
 
 .slick-headerrow-column.ui-state-default {
-  padding: 4px;
+  padding: 2px 2px 4px 2px;
 }
 
 .slick-header-column-sorted {
@@ -92,7 +92,7 @@ classes should alter those!
   border-bottom-color: silver;
 
   overflow: hidden;
-  text-overflow: ellipsis;
+  /*text-overflow: ellipsis;*/
   white-space: nowrap;
   vertical-align: middle;
   z-index: 1;


### PR DESCRIPTION
This small change prevents Firefox from showing ellipsis (...) instead of column headers. Currently when you enter some text in a column header to filter on this value, firefox displays incorrectly an ellipsis character (...) instead of the input text field containing the value supplied to filter that column.
