### PR TITLE
Two modifications

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1009,6 +1009,10 @@ if (typeof Slick === "undefined") {
       });
     }
 
+    function getSortColumns() {
+      return sortColumns;
+    }
+
     function handleSelectedRangesChanged(e, ranges) {
       selectedRows = [];
       var hash = {};
@@ -2718,6 +2722,7 @@ if (typeof Slick === "undefined") {
       "updateColumnHeader": updateColumnHeader,
       "setSortColumn": setSortColumn,
       "setSortColumns": setSortColumns,
+      "getSortColumns": getSortColumns,
       "autosizeColumns": autosizeColumns,
       "getOptions": getOptions,
       "setOptions": setOptions,


### PR DESCRIPTION
Commit b1cb786: It allows to remove columns from sortColumns with ctrlKey when multiColumnSort option is enabled. With this commit we can click a column with Control key to remove columns from sortColumns array.

Commit 0a6cfdb: adds getSortColumns() method which is useful to modify the current array of sortColumns.
