### PR TITLE
Fixed colspan bug - erroneous cell-rendering after editing

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1321,15 +1321,18 @@ if (typeof Slick === "undefined") {
         return;
       }
 
+      var columnIndex = 0
       $(rowsCache[row]).children().each(function (i) {
-        var m = columns[i], d = getDataItem(row);
+        var m = columns[columnIndex], d = getDataItem(row);
         if (row === activeRow && i === activeCell && currentEditor) {
           currentEditor.loadValue(getDataItem(activeRow));
         } else if (d) {
-          this.innerHTML = getFormatter(row, m)(row, i, getDataItemValueForColumn(d, m), m, getDataItem(row));
+          this.innerHTML = getFormatter(row, m)(row, columnIndex, getDataItemValueForColumn(d, m), m, getDataItem(row));
         } else {
           this.innerHTML = "";
         }
+
+        columnIndex += getColspan(row, i);
       });
 
       invalidatePostProcessingResults(row);


### PR DESCRIPTION
If you have a colspan at the beginning of a row and you edit a cell following the colspan, the cell rendering is erroneous. For demonstration I changed the sample 3 and added a few colspans.
https://gist.github.com/1978508

Go to Task 6 and edit the duration. Then go down a line with the cursor-down key. The cells after the edited cell are now rendered false.

I fixed this issue in this pull-request
