### PR TITLE
Fix for issue #237

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -733,6 +733,7 @@ if (typeof Slick === "undefined") {
               applyColumnHeaderWidths();
               if (options.syncColumnCellResize) {
                 applyColumnWidths();
+                handleScroll();
               }
             })
             .bind("dragend", function (e, dd) {
@@ -748,6 +749,7 @@ if (typeof Slick === "undefined") {
               }
               updateCanvasWidth(true);
               render();
+              handleScroll();
               trigger(self.onColumnsResized, {});
             });
       });


### PR DESCRIPTION
This is a fix for the issue where the column headers go out of sync with the content area in IE, when scrolled to maximum right and making the columns smaller.
