### PR TITLE
added configurable zIndex

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -4,14 +4,15 @@
     var columnCheckboxes;
 
     var defaults = {
-      fadeSpeed:250
+      fadeSpeed:250,
+      zIndex:20
     };
 
     function init() {
       grid.onHeaderContextMenu.subscribe(handleHeaderContextMenu);
       options = $.extend({}, defaults, options);
 
-      $menu = $("<span class='slick-columnpicker' style='display:none;position:absolute;z-index:20;' />").appendTo(document.body);
+      $menu = $("<span class='slick-columnpicker' style='display:none;position:absolute;' />").zIndex(options.zIndex).appendTo(document.body);
 
       $menu.bind("mouseleave", function (e) {
         $(this).fadeOut(options.fadeSpeed)


### PR DESCRIPTION
the zIndex of the columnpicker span element is set to 20, which complicates to display the columnpicker e.g. inside a jQueryUI dialog window, which sets the zIndex of the dialog to some value bigger than 1000. While I can configure the jQueryUI dialog plugin to use smaller numbers I can't do that in the slick.columnpicker. 
This is the motivation for this small pull request. It allows you to pass a zIndex along with the other options when initializing the columnpicker plugin.
