### PR TITLE
Header size bug fix

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -346,7 +346,7 @@ if (typeof Slick === "undefined") {
         headersWidth += width;
       }
 
-      return headersWidth + 1000;
+      return headersWidth + scrollbarDimensions.width + 1000;
     }
 
     function getCanvasWidth() {
@@ -365,6 +365,7 @@ if (typeof Slick === "undefined") {
 
       if (canvasWidth != oldCanvasWidth) {
         $canvas.width(canvasWidth);
+        $headers.width(getHeadersWidth());
         $headerRow.width(canvasWidth);
         viewportHasHScroll = (canvasWidth > viewportW - scrollbarDimensions.width);
       }


### PR DESCRIPTION
When the size of all the headers is superior to 10'000px there is a bug where column headers are displayed to a second line and there is also a problem when you scroll.  
This simple example induce the bug and you don't have it anymore with my fix.

```
$(document).ready(function () {
  $('#node').css({
    width:$(window).width(),
    height:$(window).height()
  });

  var numberOfCols = 100;
  var numberOfRows = 500;

  var cols = [];

  for (var i = 0; i < numberOfCols; i++) {
    cols.push({
      field:'c' + i,
      id:'c' + i,
      name:'c' + i
    });
  }

  var rows = [];

  for (var i = 0; i < numberOfRows; i++) {
    var row = {};

    for (var j = 0; j < numberOfCols; j++) {
      row['c' + j] = (Math.random() * 100).toFixed(2);
    }

    rows.push(row);
  }

  window.grid = new Slick.Grid('#node', rows, cols, {
    defaultColumnWidth:150
  });
});
```
