### PR TITLE
Clickable Elements in Column Headers

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -491,7 +491,7 @@ if (typeof Slick === "undefined") {
         // temporary workaround for a bug in jQuery 1.7.1 (http://bugs.jquery.com/ticket/11328)
         e.metaKey = e.metaKey || e.ctrlKey;
 
-        if ($(e.target).hasClass("slick-resizable-handle")) {
+        if ($(e.target).hasClass("slick-resizable-handle") || $(e.target).hasClass("noSort")) {
           return;
         }
 


### PR DESCRIPTION
This change allows users to put their own clickable elements into the headers that won't trigger a column sort.  They simply need to put the "noSort" class on the element.  The only current workaround is to give those classes the "slick-resizable-handle" class, which will cause bugs elsewhere in the code (such as column reordering).
