### PR TITLE
Multicolumn sort order indication

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -465,10 +465,9 @@ if (typeof Slick === "undefined") {
 
         if (m.sortable) {
           header.append("<span class='slick-sort-indicator' />");
-        }
-
-        if (options.multiColumnSort) {
-          header.append("<span class='slick-sort-order' />");
+          if (options.multiColumnSort) {
+            header.append("<span class='slick-sort-order' />");
+          }
         }
 
         if (options.showHeaderRow) {


### PR DESCRIPTION
When sorting on multiple columns, my users want to know what order the columns are being sorted in. I added a span to the header, immediately after the sort arrow, to show the sort order.

I'm new to git, so please excuse the mess I've made with my commits.
