### PR TITLE
build: add Makefile to build on *nix platforms

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -1,0 +1,14 @@
+GMCS = gmcs -r:System.Web.Extensions.dll -r:System.Web.dll
+
+all: minimize cleanup
+
+minifier:
+	$(GMCS) minimize.cs
+
+minimize: minifier
+	mono minimize.exe ../dist/slick.grid-{0}.min.js "\"slickGridVersion\"\s*:\s*\"(.*?)\"" ../slick.grid.js
+	mono minimize.exe ../dist/slick.grid-{0}.merged.min.js "\"slickGridVersion\"\s*:\s*\"(.*?)\""  ../lib/jquery.event.drag-2.0.min.js ../slick.grid.js
+
+cleanup:
+	rm -f minimize.exe
+


### PR DESCRIPTION
We use the gmcs compiler from mono to compile

Tested on debian / mono 2.10.8.1

These are the md5sum of 2.0.1 tarball (mleibman-SlickGrid-2.0.1-0-g505c908.tar.gz):
8af2e8ea05c7c6479dd527ffb54530e7  slick.grid-2.0.merged.min.js
48a72407414c930ad3a0963cfc2416dd  slick.grid-2.0.min.js
ded0ac448a44c52943343165744377ff  slick.grid-2.0.merged.min.orig.js
69d6c034345cdf397eb9d6417a5116a3  slick.grid-2.0.min.orig.js

Do they match? :)
