### PR TITLE
Changing filter's default behaviour from Sensitive to Insensitive case filtering

### DIFF
--- a/examples/example4-model.html
+++ b/examples/example4-model.html
@@ -144,7 +144,7 @@ function myFilter(item, args) {
     return false;
   }
 
-  if (args.searchString != "" && item["title"].indexOf(args.searchString) == -1) {
+  if (args.searchString.toLowerCase() != "" && item["title"].toLowerCase().indexOf(args.searchString) == -1) {
     return false;
   }
 


### PR DESCRIPTION
Default behaviour suppose to to support insensitive case filtering, and not as it is now. I do not think most of the users will want to search using a case-sensitive filter.

Future commit of mine suppose to allow the user to define his needs using a variable.
