### PR TITLE
Set a CSS class on the active row so it can be highlighted

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2056,6 +2056,7 @@ if (typeof Slick === "undefined") {
       if (activeCellNode !== null) {
         makeActiveCellNormal();
         $(activeCellNode).removeClass("active");
+        $(activeCellNode).parent().removeClass("active-row");
       }
 
       var activeCellChanged = (activeCellNode !== newCell);
@@ -2066,6 +2067,7 @@ if (typeof Slick === "undefined") {
         activeCell = activePosX = getCellFromNode(activeCellNode);
 
         $(activeCellNode).addClass("active");
+        $(activeCellNode).parent().addClass("active-row");
 
         if (options.editable && editMode && isCellPotentiallyEditable(activeRow, activeCell)) {
           clearTimeout(h_editorLoader);


### PR DESCRIPTION
In a large grid, it's helpful to highlight the active row as a visual aid, similar to how modern text editors highlight the active row of text.

The implementation is very simple.
