### PR TITLE
Date editor DatePicker options

### DIFF
--- a/slick.editors.js
+++ b/slick.editors.js
@@ -156,22 +156,25 @@
     var defaultValue;
     var scope = this;
     var calendarOpen = false;
+    var datePickerOptions = {
+      showOn: "button",
+      buttonImageOnly: true,
+      buttonImage: "../images/calendar.gif",
+      beforeShow: function () {
+        calendarOpen = true;
+      },
+      onClose: function () {
+        calendarOpen = false;
+      }
+    };
+    // Override DatePicker options from datePickerOptions on column definition
+    $.extend(datePickerOptions, args.column.datePickerOptions);
 
     this.init = function () {
       $input = $("<INPUT type=text class='editor-text' />");
       $input.appendTo(args.container);
       $input.focus().select();
-      $input.datepicker({
-        showOn: "button",
-        buttonImageOnly: true,
-        buttonImage: "../images/calendar.gif",
-        beforeShow: function () {
-          calendarOpen = true
-        },
-        onClose: function () {
-          calendarOpen = false
-        }
-      });
+      $input.datepicker(datePickerOptions);
       $input.width($input.width() - 18);
     };
 


### PR DESCRIPTION
I wanted to be able to set the path to the DatePicker button image on the DatePicker used in the Date Editor. So I've allowed the Picker options to be set from the column definition.

Please let me know if you'd be happy with the API change specified? I haven't formally tested it yet as I couldn't get the tests to run.
