### PR TITLE
fixed bug where the last row in the grid was invalidated although it still was in the data-range

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1513,7 +1513,7 @@ if (typeof Slick === "undefined") {
       // this helps avoid redundant calls to .removeRow() when the size of the data decreased by thousands of rows
       var l = options.enableAddRow ? getDataLength() : getDataLength() - 1;
       for (var i in rowsCache) {
-        if (i >= l) {
+        if (i > l) {
           removeRowFromCache(i);
         }
       }


### PR DESCRIPTION
when the data-length is already adjusted to length - 1 to reflect a zero-based row index it should later be checked for '<', not for '<=', right?

thanks for an awesome grid btw! :)
