### PR TITLE
Changed to allow selecting multiple ranges per row

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1098,8 +1098,8 @@ if (typeof Slick === "undefined") {
         for (var j = ranges[i].fromRow; j <= ranges[i].toRow; j++) {
           if (!hash[j]) {  // prevent duplicates
             selectedRows.push(j);
+            hash[j] = {};
           }
-          hash[j] = {};
           for (var k = ranges[i].fromCell; k <= ranges[i].toCell; k++) {
             if (canCellBeSelected(j, k)) {
               hash[j][columns[k].id] = options.selectedCellCssClass;


### PR DESCRIPTION
A tiny change to support selection models that put more than one range in the same row.  For example, I want to select columns, including selecting multiple columns with non-selected columns in between.

Without this change, the code only applies the CSS style indicating selection to one Range object's cells within any given row.
