### PR TITLE
Expose getRowFromNode externally 

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3127,6 +3127,7 @@ if (typeof Slick === "undefined") {
       "getCellEditor": getCellEditor,
       "getCellNode": getCellNode,
       "getCellNodeBox": getCellNodeBox,
+      "getRowFromNode": getRowFromNode,
       "canCellBeSelected": canCellBeSelected,
       "canCellBeActive": canCellBeActive,
       "navigatePrev": navigatePrev,


### PR DESCRIPTION
I was using slickgrid 2.0a for quite a while and updated to version 2.1 recently. I have noticed that there is no easy way now to access a data item by just having a DOM node. I used to be able to do this by reading the "row" attribute off of the slick-row, however that does not exist in the latest version. getRowFromNode handles this well and exposing it will be of great benefit. 

it will allow
- easy extension when using an external library that wraps around slickgrid
