### PR TITLE
LongTextEditor should use args.grid

### DIFF
--- a/slick.editors.js
+++ b/slick.editors.js
@@ -445,10 +445,10 @@
         scope.cancel();
       } else if (e.which == $.ui.keyCode.TAB && e.shiftKey) {
         e.preventDefault();
-        grid.navigatePrev();
+        args.grid.navigatePrev();
       } else if (e.which == $.ui.keyCode.TAB) {
         e.preventDefault();
-        grid.navigateNext();
+        args.grid.navigateNext();
       }
     };
 


### PR DESCRIPTION
LongTextEditor should use `args.grid` and not rely on a global `grid` variable
