### PR TITLE
fixed bug where ancestor-bindings were not removed

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -429,7 +429,7 @@ if (typeof Slick === "undefined") {
       return supportedHeight;
     }
 
- // TODO:  this is static.  need to handle page mutation.
+    // TODO:  this is static.  need to handle page mutation.
     function bindAncestorScrollEvents() {
       var elem = $canvas[0];
       while ((elem = elem.parentNode) != document.body && elem != null) {
@@ -437,7 +437,7 @@ if (typeof Slick === "undefined") {
         if (elem == $viewport[0] || elem.scrollWidth != elem.clientWidth || elem.scrollHeight != elem.clientHeight) {
           var $elem = $(elem);
           if (!$boundAncestors) {
-        	$boundAncestors = $elem;
+            $boundAncestors = $elem;
           } else {
             $boundAncestors = $boundAncestors.add($elem);
           }


### PR DESCRIPTION
In case the canvas-element is detached from the dom before the grid-instance is
destroyed, the unbinding from the canvas-elements' parents does not work reliably.
