### PR TITLE
Fix for Cell text content selection in non IE Browsers

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2150,7 +2150,7 @@ if (typeof Slick === "undefined") {
       if (!currentEditor) {
         // if this click resulted in some cell child node getting focus,
         // don't steal it back - keyboard events will still bubble up
-        if (e.target != document.activeElement) {
+        if (options.editable && e.target != document.activeElement) {
           setFocus();
         }
       }


### PR DESCRIPTION
Small fix that make it possible to select and copy/past cell text content
in non IE browsers. By default text selection within cells is disabled via the
enableTextSelectionOnCells = false property. 
Apparently cell text selection  only works correctly in IE - lines 266-271 of file slick.grid.js

```
    // for usability reasons, all text selection in SlickGrid is disabled
    // with the exception of input and textarea elements (selection must
    // be enabled there so that editors work as expected); note that
    // selection in grid cells (grid body) is already unavailable in
    // all browsers except IE
    disableSelection($headers); // disable all text selection in header (including input and textarea)
```

I added a change to the handleClick event listener that fix the problem in the other browsers.
