### PR TITLE
headerHeight parameter to be able to set the header height as an option.

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -73,6 +73,7 @@ if (typeof Slick === "undefined") {
       editorLock: Slick.GlobalEditorLock,
       showHeaderRow: false,
       headerRowHeight: 25,
+      headerHeight: 25,
       showTopPanel: false,
       topPanelHeight: 25,
       formatterFactory: null,
@@ -485,6 +486,7 @@ if (typeof Slick === "undefined") {
             .attr("title", m.toolTip || "")
             .data("column", m)
             .addClass(m.headerCssClass || "")
+            .css("height", options.headerHeight - headerColumnHeightDiff)
             .appendTo($headers);
 
         if (options.enableColumnReorder || m.sortable) {


### PR DESCRIPTION
This `headerHeight` option makes it possible to set the header height without changing the stylesheets, along with the other options.
