### PR TITLE
Fix for issue #450, create dummy columns array

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -183,6 +183,10 @@ if (typeof Slick === "undefined") {
         throw new Error("SlickGrid requires a valid container, " + container + " does not exist in the DOM.");
       }
 
+	  if (!columns || !columns.length) {
+		  columns = [{}];
+	  }
+	  
       // calculate these only once and share between grid instances
       maxSupportedCssHeight = maxSupportedCssHeight || getMaxSupportedCssHeight();
       scrollbarDimensions = scrollbarDimensions || measureScrollbar();


### PR DESCRIPTION
I noticed that if you pass an empty array of columns into the constructor (which I did as I was setting columns later after user interaction), the grid will be created fine, but column reordering stops working.

The easiest solution seemed to be to just create a dummy array, instead of modifying lots more code further down to check for an empty column list.
