### PR TITLE
Bug Fix: viewportHasHScroll now updates during resize of both canvas and viewport

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -396,8 +396,9 @@ if (typeof Slick === "undefined") {
         $canvas.width(canvasWidth);
         $headerRow.width(canvasWidth);
         $headers.width(getHeadersWidth());
-        viewportHasHScroll = (canvasWidth > viewportW - scrollbarDimensions.width);
       }
+
+      viewportHasHScroll = (canvasWidth > viewportW - scrollbarDimensions.width);
 
       $headerRowSpacer.width(canvasWidth + (viewportHasVScroll ? scrollbarDimensions.width : 0));
 


### PR DESCRIPTION
....

Fixed a bug where viewportHasHScroll was only updated when the canvas width changed. Now it updates when either the canvas width or the viewport width change. This bug was causing issues when attempting to sync scrolling between SlickGrid and another view.
