### PR TITLE
Adding "previous value" and "new value" properties to onCellChanged event args

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3028,7 +3028,9 @@ if (typeof Slick === "undefined") {
               trigger(self.onCellChange, {
                 row: activeRow,
                 cell: activeCell,
-                item: item
+                item: item,
+                previousValue: editCommand.prevSerializedValue,
+                newValue: editCommand.serializedValue
               });
             } else {
               var newItem = {};


### PR DESCRIPTION
We would like the ability to make an AJAX request to update the original datasource when a cell is changed. I'm sure we're not alone wanting to do this so I have added previousValue and newValue properties to onCellChanged event args.

Property values are populated from the editCommand object which is built in the lines above the args object being created to avoid needing to know about any editors, or needing to call currentEditor.serializeValue() again which could incur some overhead depending on the type and/or volume of data to be serialised*.
- (Apologies for the British spellings :P).
