### PR TITLE
Fix for Safari 6 toString() defaultFormatter bug

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1313,7 +1313,7 @@ if (typeof Slick === "undefined") {
       if (value == null) {
         return "";
       } else {
-        return value.toString().replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+        return (value + "").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
       }
     }
 


### PR DESCRIPTION
On Safari 6 in Lion, the toString() method will fail with the message `TypeError: Type error` when parsing certain numeric data _if the Error Console is not open._ If the Error Console is open, the error does not occur. This bug doesn't occur in Safari 5.

Due to the strangeness of this bug, I'm assuming it's browser specific. To get around this bug, I used string concatenation, rather than the toString() method.
