### PR TITLE
Improve jQuery UI Sortable fix

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -652,9 +652,7 @@ if (typeof Slick === "undefined") {
     }
 
     function setupColumnReorder() {
-      // force init jquery ui sortable +1.9
-      $headers.sortable();
-      $headers.sortable("destroy");
+      $headers.filter(":ui-sortable").sortable("destroy");
       $headers.sortable({
         containment: "parent",
         axis: "x",


### PR DESCRIPTION
The `:ui-sortable` pseudo-selector filters out the element if it hasn't been initialized as a Sortable.
