### PR TITLE
Add ui-state-disabled class to the container of the paging button

### DIFF
--- a/controls/slick.pager.css
+++ b/controls/slick.pager.css
@@ -16,6 +16,7 @@
   display: inline-block;
   margin: 2px;
   border-color: gray;
+  cursor: pointer;
 }
 
 .slick-pager .slick-pager-nav {

--- a/controls/slick.pager.js
+++ b/controls/slick.pager.js
@@ -121,15 +121,19 @@
       $container.find(".slick-pager-nav span").removeClass("ui-state-disabled");
       if (!state.canGotoFirst) {
         $container.find(".ui-icon-seek-first").addClass("ui-state-disabled");
+        $container.find(".ui-icon-seek-first").parent().addClass("ui-state-disabled");
       }
       if (!state.canGotoLast) {
         $container.find(".ui-icon-seek-end").addClass("ui-state-disabled");
+        $container.find(".ui-icon-seek-end").parent().addClass("ui-state-disabled");
       }
       if (!state.canGotoNext) {
         $container.find(".ui-icon-seek-next").addClass("ui-state-disabled");
+        $container.find(".ui-icon-seek-next").parent().addClass("ui-state-disabled");
       }
       if (!state.canGotoPrev) {
         $container.find(".ui-icon-seek-prev").addClass("ui-state-disabled");
+        $container.find(".ui-icon-seek-prev").parent().addClass("ui-state-disabled");
       }
 
       if (pagingInfo.pageSize == 0) {


### PR DESCRIPTION
This makes semantic sense as the container contains the `ui-state-default` class. It also allows for styling to be applied conditionally to the container of a disabled button without using JavaScript. Also, it makes it much more clear which buttons are disabled when using the default styling.

For example, if the container had `cursor: pointer` applied and needed to be reset to `cursor: default` on a disabled button, this would currently not be possible without using JavaScript to find the parents of the disabled icons.
