### PR TITLE
Please add the distance delay to the standard code.

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -656,7 +656,7 @@ if (typeof Slick === "undefined") {
       $headers.filter(":ui-sortable").sortable("destroy");
       $headers.sortable({
         containment: "parent",
-        distance: 5,
+        distance: 3,
         axis: "x",
         cursor: "default",
         tolerance: "intersection",


### PR DESCRIPTION
Added a small distance delay on the sortable to prevent users from unintended
triggering of the reordering. (Happens all the time i'm using slickgrid).
i.e. the users tries to sort the column but fails since his mouse was still
on the move a little bit and 1px is enough to trigger reordeing here.
Please try, it still feels very responsive.
