### PR TITLE
Use of navigator.userAgent instead of $.browser

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -423,7 +423,7 @@ if (typeof Slick === "undefined") {
     function getMaxSupportedCssHeight() {
       var supportedHeight = 1000000;
       // FF reports the height back but still renders blank after ~6M px
-      var testUpTo = ($.browser.mozilla) ? 6000000 : 1000000000;
+      var testUpTo = navigator.userAgent.toLowerCase().match(/firefox/) ? 6000000 : 1000000000;
       var div = $("<div style='display:none' />").appendTo(document.body);
 
       while (true) {


### PR DESCRIPTION
$.browser object has been removed from jQuery 1.9.0 ([source](http://jquery.com/upgrade-guide/1.9/#jquery-browser-removed))
