### PR TITLE
stop truncating the final row in the table on resize

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1584,7 +1584,7 @@ if (typeof Slick === "undefined") {
       // this helps avoid redundant calls to .removeRow() when the size of the data decreased by thousands of rows
       var l = options.enableAddRow ? getDataLength() : getDataLength() - 1;
       for (var i in rowsCache) {
-        if (i >= l) {
+        if (i > l) {
           removeRowFromCache(i);
         }
       }


### PR DESCRIPTION
Fixes the bug discussed here: https://github.com/mleibman/SlickGrid/issues/249

Recap: 
The bug manifests by forcing the last row of the table to re-render on each canvasResize call.
