### PR TITLE
Fix wiki link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to SlickGrid
 
-For now, please check out [the wiki](/mleibman/SlickGrid/wiki).
+For now, please check out [the wiki](https://github.com/mleibman/SlickGrid/wiki).
 
 ## SlickGrid is an advanced JavaScript grid/spreadsheet component
 


### PR DESCRIPTION
The wiki link in the README currently links to a 404, as GitHub transforms the current path into a URL for the blob of the wiki, which doesn't exist. This may be due to GitHub's [new support of relative links](https://github.com/blog/1395-relative-links-in-markup-files).

Using a full URL resolves this. There may be a better solution that preserves the relativeness of the path; if anyone knows of one, definitely chime in!
