### PR TITLE
Adding default focusable column option, plus minor optimization to canCellBeActive

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2988,11 +2988,7 @@ if (typeof Slick === "undefined") {
         return columnMetadata[cell].focusable;
       }
 
-      if (typeof columns[cell].focusable === "boolean") {
-        return columns[cell].focusable;
-      }
-
-      return true;
+      return columns[cell].focusable;
     }
 
     function canCellBeSelected(row, cell) {


### PR DESCRIPTION
I was in the middle of updating the [Column Options documentation](https://github.com/mleibman/SlickGrid/wiki/Column-Options), and while researching `focusable` I noticed that it didn't get assigned a default value. In 5ad8c99 I've added the appropriate default (`true`) and in 9431ed9 I slightly optimized `canCellBeActive` now that we can assume a boolean.
