### PR TITLE
Default selectable column option, minor optimization of canCellBeSelected

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -96,7 +96,8 @@ if (typeof Slick === "undefined") {
       rerenderOnResize: false,
       headerCssClass: null,
       defaultSortAsc: true,
-      focusable: true
+      focusable: true,
+      selectable: true
     };
 
     // scroller
@@ -3006,11 +3007,7 @@ if (typeof Slick === "undefined") {
         return columnMetadata.selectable;
       }
 
-      if (typeof columns[cell].selectable === "boolean") {
-        return columns[cell].selectable;
-      }
-
-      return true;
+      return columns[cell].selectable;
     }
 
     function gotoCell(row, cell, forceEdit) {


### PR DESCRIPTION
This is the exact same change as PR #538, but with `selectable` instead of `focusable`. Assigns a default value of `true` to columns, and we no longer have to test to see if `selectable` is a boolean in `canCellBeSelected`.
