### PR TITLE
Create an event for when column definitions change.

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1203,6 +1203,9 @@ if (typeof Slick === "undefined") {
         resizeCanvas();
         applyColumnWidths();
         handleScroll();
+        trigger(self.onColumnsSet, {
+            "columns": columns
+        });
       }
     }
 
@@ -3197,6 +3200,7 @@ if (typeof Slick === "undefined") {
       "onViewportChanged": new Slick.Event(),
       "onColumnsReordered": new Slick.Event(),
       "onColumnsResized": new Slick.Event(),
+      "onColumnsSet": new Slick.Event(),
       "onCellChange": new Slick.Event(),
       "onBeforeEditCell": new Slick.Event(),
       "onBeforeCellEditorDestroy": new Slick.Event(),


### PR DESCRIPTION
This pull request adds a new `onColumnsSet` event to allow responding to changes in the column definitions. The event is fired from `setColumns` if the grid has actually been initialized.

This is useful if, for instance, the ColumnPicker plugin is being used, and you want to store the currently active column definitions so they can be re-applied on subsequent page loads. I could not find a better way to do this -- `getColumns` alone doesn't answer the question of "whenever the column definitions have changed" -- but I may have missed something.

Let me know if you'd consider this or have questions about the implementation thus far, I think this is generally useful.
