### PR TITLE
Checkbox editor ValueChanged event behavior fix

### DIFF
--- a/slick.editors.js
+++ b/slick.editors.js
@@ -302,22 +302,16 @@
     };
 
     this.loadValue = function (item) {
-      defaultValue = item[args.column.field];
+      defaultValue = !!item[args.column.field];
       if (defaultValue) {
-        defaultValue = true;
         $select.attr("checked", "checked");
       } else {
-        defaultValue = false;
         $select.removeAttr("checked");
       }
     };
 
     this.serializeValue = function () {
-      if ($select.attr("checked") === 'checked') {
-        return true;
-      } else {
-        return false;
-      }
+      return !!$select.attr("checked");
     };
 
     this.applyValue = function (item, state) {
@@ -325,11 +319,7 @@
     };
 
     this.isValueChanged = function () {
-      if ($select.attr("checked") === 'checked') {
-        return !defaultValue;
-      } else {
-        return defaultValue;
-      }
+      return (this.serializeValue() !== defaultValue);
     };
 
     this.validate = function () {


### PR DESCRIPTION
Checkbox editor was firing onCellChange event even when there was no change. This fixes that behavior and also returns a boolean on serialzeValue instead of the previous "checked" or undefined.
