### PR TITLE
Remove usage on $.browser for jquery 1.9.0

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2486,7 +2486,7 @@ if (typeof Slick === "undefined") {
 
       // if there previously was text selected on a page (such as selected text in the edit cell just removed),
       // IE can't set focus to anything else correctly
-      if ($.browser.msie) {
+      if (navigator.userAgent.toLowerCase().match(/msie/)) {
         clearTextSelection();
       }
 


### PR DESCRIPTION
jquery 1.9 has removed support for $.browser, use navigator.userAgent
instead
