### PR TITLE
Add option to hide totals row.

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -59,7 +59,8 @@
       aggregateEmpty: false,
       aggregateCollapsed: false,
       aggregateChildGroups: false,
-      collapsed: false
+      collapsed: false,
+      displayTotalsRow: true
     };
     var groupingInfos = [];
     var groups = [];
@@ -579,7 +580,7 @@
           }
         }
 
-        if (g.totals && (!g.collapsed || gi.aggregateCollapsed)) {
+        if (g.totals && gi.displayTotalsRow && (!g.collapsed || gi.aggregateCollapsed)) {
           groupedRows[gl++] = g.totals;
         }
       }


### PR DESCRIPTION
Allow groups to exclude the subtotals from the rendered grid.

This is to allow using group formatters to display aggregate information in the group header rather than in a footer section (if desired).
I'm sure there are other uses as well, I just haven't been able to think of any.

Also added a new groupingInfoOption:
- displayTotalsRow (defaults to true).

We'll see if Github is smart enough to update the existing pull request.
