### PR TITLE
Update internal column cache when columns are reordered

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -9,6 +9,7 @@
 
     function init() {
       grid.onHeaderContextMenu.subscribe(handleHeaderContextMenu);
+      grid.onColumnsReordered.subscribe(updateColumnOrder);
       options = $.extend({}, defaults, options);
 
       $menu = $("<span class='slick-columnpicker' style='display:none;position:absolute;z-index:20;' />").appendTo(document.body);


### PR DESCRIPTION
Presently, the columnPicker control does not coexist well with grids that have sortable columns, because it uses the original column order to generate the control. This PR adds a simple handler that updates the `columns` reference whenever the columns are reordered.
