### PR TITLE
bugfix column can grow larger than its maxwidth

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1059,7 +1059,7 @@ if (typeof Slick === "undefined") {
           var currentWidth = widths[i];
           var growSize;
 
-          if (!c.resizable || c.maxWidth <= widths[i]) {
+          if (!c.resizable || c.maxWidth <= currentWidth) {
             growSize = 0;
           } else {
             growSize = Math.min(Math.floor(growProportion * currentWidth) - currentWidth, (c.maxWidth - currentWidth) || 1000000) || 1;


### PR DESCRIPTION
I reproduced the issue in http://jsbin.com/ahahaz/5/edit . I also replaced the `continue` statement by a size grow of `0`. The `continue` was skipping the anti-infinite loop check
