### PR TITLE
update the active cell on handleContextMenu

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2239,9 +2239,11 @@ if (typeof Slick === "undefined") {
         return;
       }
 
-      //set the active cell to update the ui
-      var c = getCellFromEvent(e);
-      setActiveCell(c.row, c.cell);
+      //set the active cell to update the ui - don't update ui if multiple rows are already selected
+      if(getSelectedRows().length < 2){
+        var c = getCellFromEvent(e);
+        setActiveCell(c.row, c.cell);
+      }
 
       trigger(self.onContextMenu, {}, e);
     }


### PR DESCRIPTION
Updates the active cell in order to allow the UI (or other internal code) to update when a context menu is selected.

See: https://github.com/mleibman/SlickGrid/issues/585
