### PR TITLE
Applied fix to destroy error with JQuery 1.9.

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -975,8 +975,8 @@ if (typeof Slick === "undefined") {
         unregisterPlugin(plugins[i]);
       }
 
-      if (options.enableColumnReorder && $headers.sortable) {
-        $headers.sortable("destroy");
+      if (options.enableColumnReorder) {
+          $headers.filter(":ui-sortable").sortable("destroy");
       }
 
       unbindAncestorScrollEvents();


### PR DESCRIPTION
Closes issue: https://github.com/mleibman/SlickGrid/issues/484

Prevents and error generated when destroy is called multiple times on the $headers variable due to the .sortable property still being true after destroy has previously been called in JQuery 1.9.

```
Error: cannot call methods on sortable prior to initialization; attempted to call method 'destroy'
```
