### PR TITLE
Stop propagation of click event in showMenu

### DIFF
--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -233,6 +233,10 @@
       $activeHeaderColumn = $menuButton.closest(".slick-header-column");
       $activeHeaderColumn
         .addClass("slick-header-column-active");
+
+      // Stop propagation so that it doesn't register as a header click event.
+      e.preventDefault();
+      e.stopPropagation();
     }
 
 


### PR DESCRIPTION
Stop propagation of click event in showMenu as otherwise the column
sorting is triggered
