### PR TITLE
Add onColumnsSet event triggered when setColumns is called

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1206,6 +1206,8 @@ if (typeof Slick === "undefined") {
         applyColumnWidths();
         handleScroll();
       }
+
+      trigger(self.onColumnsSet, {})
     }
 
     function getOptions() {
@@ -3198,6 +3200,7 @@ if (typeof Slick === "undefined") {
       "onViewportChanged": new Slick.Event(),
       "onColumnsReordered": new Slick.Event(),
       "onColumnsResized": new Slick.Event(),
+      "onColumnsSet": new Slick.Event(),
       "onCellChange": new Slick.Event(),
       "onBeforeEditCell": new Slick.Event(),
       "onBeforeCellEditorDestroy": new Slick.Event(),


### PR DESCRIPTION
Currently SlickGrid triggers no event when columns are hidden/shown, for example by the columnpicker. Such an event is useful if we want to persist the UI's state.

I suggest this two-line change that adds a new onColumnsSet event, triggered every time setColumns is called, with an empty args paramater, in the vein of the other columns-related events (user can call getColumns).
