### PR TITLE
pass row metadata to the editorFactory delegator

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1361,7 +1361,7 @@ if (typeof Slick === "undefined") {
         return columnMetadata[cell].editor;
       }
 
-      return column.editor || (options.editorFactory && options.editorFactory.getEditor(column));
+      return column.editor || (options.editorFactory && options.editorFactory.getEditor(column, rowMetadata));
     }
 
     function getDataItemValueForColumn(item, columnDef) {


### PR DESCRIPTION
In some cases it might be desirable to block editing for certain cells. Although this can be done in the editor (disabling an input field for example), it may also be desirable to keep the editor from being initialized at all
