### PR TITLE
Make SlickGrid more accessible.

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -548,7 +548,7 @@ if (typeof Slick === "undefined") {
       for (var i = 0; i < columns.length; i++) {
         var m = columns[i];
 
-        var header = $("<div class='ui-state-default slick-header-column' id='" + uid + m.id + "' role='gridcell' />")
+        var header = $("<div class='ui-state-default slick-header-column' id='" + uid + m.id + "' role='columnheader' />")
             .html("<span class='slick-column-name'>" + m.name + "</span>")
             .width(m.width - headerColumnWidthDiff)
             .attr("title", m.toolTip || "")

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -222,6 +222,7 @@ if (typeof Slick === "undefined") {
           .css("overflow", "hidden")
           .css("outline", 0)
           .addClass(uid)
+          .attr('role', 'grid')
           .addClass("ui-widget");
 
       // set up a positioning container if needed
@@ -232,7 +233,7 @@ if (typeof Slick === "undefined") {
       $focusSink = $("<div tabIndex='0' hideFocus style='position:fixed;width:0;height:0;top:0;left:0;outline:0;'></div>").appendTo($container);
 
       $headerScroller = $("<div class='slick-header ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($container);
-      $headers = $("<div class='slick-header-columns' style='left:-1000px' />").appendTo($headerScroller);
+      $headers = $("<div class='slick-header-columns' style='left:-1000px' role='row' />").appendTo($headerScroller);
       $headers.width(getHeadersWidth());
 
       $headerRowScroller = $("<div class='slick-headerrow ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($container);
@@ -547,7 +548,7 @@ if (typeof Slick === "undefined") {
       for (var i = 0; i < columns.length; i++) {
         var m = columns[i];
 
-        var header = $("<div class='ui-state-default slick-header-column' id='" + uid + m.id + "' />")
+        var header = $("<div class='ui-state-default slick-header-column' id='" + uid + m.id + "' role='gridcell' />")
             .html("<span class='slick-column-name'>" + m.name + "</span>")
             .width(m.width - headerColumnWidthDiff)
             .attr("title", m.toolTip || "")
@@ -1385,7 +1386,7 @@ if (typeof Slick === "undefined") {
         rowCss += " " + metadata.cssClasses;
       }
 
-      stringArray.push("<div class='ui-widget-content " + rowCss + "' style='top:" + getRowTop(row) + "px'>");
+      stringArray.push("<div class='ui-widget-content " + rowCss + "' style='top:" + getRowTop(row) + "px' role='row'>");
 
       var colspan, m;
       for (var i = 0, ii = columns.length; i < ii; i++) {
@@ -1433,7 +1434,9 @@ if (typeof Slick === "undefined") {
         }
       }
 
-      stringArray.push("<div class='" + cellCss + "'>");
+      stringArray.push("<div class='" + cellCss +
+                       "' aria-describedby='" + uid + m.id +
+                       "' tabindex='-1' role='gridcell'>");
 
       // if there is a corresponding row (if not, this is the Add New row or this data hasn't been loaded yet)
       if (d) {
@@ -2441,6 +2444,7 @@ if (typeof Slick === "undefined") {
       }
 
       if (activeCellChanged) {
+        activeCellNode.focus();
         trigger(self.onActiveCellChanged, getActiveCell());
       }
     }


### PR DESCRIPTION
SlickGrid doesn't work for people who use screen readers right now.  When navigating the grid with the keyboard, screen readers aren't aware that anything is happening.  This change introduces a few simple changes that make slick grid much more usable for people that have to use a screen reader:

1) focus() cells as they are made active in slickgrid.  This notifies screen readers that focus has changed so that they can read the cell (and the column header).

2) add aria-grid attributes so that screenreaders are aware the divs in slick grid make up a table.  This is usually very useful for table-y things like slickgrid, although the spec doesn't allow us to specify how many rows the grid has so it is somewhat deceptive (it will read something like "table with N columns and M rows" (where M is 40 instead of 2000, for instance).  I think this is a reasonable trade-off because it still gives blind people some contextual information about what the grid is and how many columns it has.

I'll make a few more notes in the code.
