### PR TITLE
Move Slick.Plugins.HeaderMenu options.buttonImage from JS to CSS.

### DIFF
--- a/plugins/slick.headermenu.css
+++ b/plugins/slick.headermenu.css
@@ -7,6 +7,7 @@
   width: 14px;
   background-repeat: no-repeat;
   background-position: left center;
+  background-image: url(../images/down.gif);
   cursor: pointer;
 
   display: none;

--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -83,7 +83,6 @@
     var _handler = new Slick.EventHandler();
     var _defaults = {
       buttonCssClass: null,
-      buttonImage: "../images/down.gif"
     };
     var $menu;
     var $activeHeaderColumn;


### PR DESCRIPTION
May be there is reason, but i can't understand the purpose of the buttonImage property in Slick.Plugins.HeaderMenu constructor options. Why not use CSS file instead?
For developer, who using SlickGrid, It's inconvenient to fix one part images url in CSS, another part in JS.
