### PR TITLE
AMD: Adding Universal Module Definition for package loaders

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -1,4 +1,15 @@
-(function ($) {
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else {
+    // Browser globals
+    root.Slick.Controls = root.Slick.Controls || {};
+    root.Slick.Controls.ColumnPicker = factory(root.jQuery);
+  }
+}(this, function ($) {
+
   function SlickColumnPicker(columns, grid, options) {
     var $menu;
     var columnCheckboxes;
@@ -108,6 +119,6 @@
     init();
   }
 
-  // Slick.Controls.ColumnPicker
-  $.extend(true, window, { Slick:{ Controls:{ ColumnPicker:SlickColumnPicker }}});
-})(jQuery);
+  return SlickColumnPicker;
+
+}));

--- a/controls/slick.pager.js
+++ b/controls/slick.pager.js
@@ -1,4 +1,15 @@
-(function ($) {
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery', '../slick.core'], factory);
+  } else {
+    // Browser globals
+    root.Slick.Controls = root.Slick.Controls || {};
+    root.Slick.Controls.Pager = factory(root.jQuery, root.Slick);
+  }
+}(this, function ($, Slick) {
+
   function SlickGridPager(dataView, grid, $container) {
     var $status;
 
@@ -142,6 +153,6 @@
     init();
   }
 
-  // Slick.Controls.Pager
-  $.extend(true, window, { Slick:{ Controls:{ Pager:SlickGridPager }}});
-})(jQuery);
+  return SlickGridPager;
+
+}));

--- a/plugins/slick.autotooltips.js
+++ b/plugins/slick.autotooltips.js
@@ -1,11 +1,13 @@
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "AutoTooltips": AutoTooltips
-    }
-  });
-
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else {
+    // Browser globals
+    root.Slick.AutoTooltips = factory(root.jQuery);
+  }
+}(this, function ($) {
 
   function AutoTooltips(options) {
     var _grid;
@@ -45,4 +47,7 @@
       "destroy": destroy
     });
   }
-})(jQuery);
+
+  return AutoTooltips;
+
+}));

--- a/plugins/slick.cellcopymanager.js
+++ b/plugins/slick.cellcopymanager.js
@@ -1,11 +1,13 @@
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "CellCopyManager": CellCopyManager
-    }
-  });
-
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery', '../slick.core'], factory);
+  } else {
+    // Browser globals
+    root.Slick.CellCopyManager = factory(root.jQuery, root.Slick);
+  }
+}(this, function ($, Slick) {
 
   function CellCopyManager() {
     var _grid;
@@ -83,4 +85,7 @@
       "onPasteCells": new Slick.Event()
     });
   }
-})(jQuery);
+
+  return CellCopyManager;
+
+}));

--- a/plugins/slick.cellrangedecorator.js
+++ b/plugins/slick.cellrangedecorator.js
@@ -1,10 +1,13 @@
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "CellRangeDecorator": CellRangeDecorator
-    }
-  });
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else {
+    // Browser globals
+    root.Slick.CellRangeDecorator = factory(root.jQuery);
+  }
+}(this, function ($) {
 
   /***
    * Displays an overlay on top of a given cell range.
@@ -61,4 +64,7 @@
       "hide": hide
     });
   }
-})(jQuery);
+
+  return CellRangeDecorator;
+
+}));

--- a/plugins/slick.cellrangeselector.js
+++ b/plugins/slick.cellrangeselector.js
@@ -1,11 +1,13 @@
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "CellRangeSelector": CellRangeSelector
-    }
-  });
-
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery', '../slick.core', './slick.cellrangedecorator'], factory);
+  } else {
+    // Browser globals
+    root.Slick.CellRangeSelector = factory(root.jQuery, root.Slick, root.Slick.CellRangeDecorator);
+  }
+}(this, function ($, Slick, CellRangeDecorator) {
 
   function CellRangeSelector(options) {
     var _grid;
@@ -23,7 +25,7 @@
 
     function init(grid) {
       options = $.extend(true, {}, _defaults, options);
-      _decorator = new Slick.CellRangeDecorator(grid, options);
+      _decorator = new CellRangeDecorator(grid, options);
       _grid = grid;
       _canvas = _grid.getCanvasNode();
       _handler
@@ -108,4 +110,7 @@
       "onCellRangeSelected": new Slick.Event()
     });
   }
-})(jQuery);
+
+  return CellRangeSelector;
+
+}));

--- a/plugins/slick.cellselectionmodel.js
+++ b/plugins/slick.cellselectionmodel.js
@@ -1,18 +1,20 @@
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "CellSelectionModel": CellSelectionModel
-    }
-  });
-
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery', '../slick.core', './slick.cellrangeselector'], factory);
+  } else {
+    // Browser globals
+    root.Slick.CellSelectionModel = factory(root.jQuery, root.Slick, root.Slick.CellRangeSelector);
+  }
+}(this, function ($, Slick, CellRangeSelector) {
 
   function CellSelectionModel(options) {
     var _grid;
     var _canvas;
     var _ranges = [];
     var _self = this;
-    var _selector = new Slick.CellRangeSelector({
+    var _selector = new CellRangeSelector({
       "selectionCss": {
         "border": "2px solid black"
       }
@@ -89,4 +91,7 @@
       "onSelectedRangesChanged": new Slick.Event()
     });
   }
-})(jQuery);
+
+  return CellSelectionModel;
+
+}));

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -1,11 +1,13 @@
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "CheckboxSelectColumn": CheckboxSelectColumn
-    }
-  });
-
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery', '../slick.core'], factory);
+  } else {
+    // Browser globals
+    root.Slick.CheckboxSelectColumn = factory(root.jQuery, root.Slick);
+  }
+}(this, function ($, Slick) {
 
   function CheckboxSelectColumn(options) {
     var _grid;
@@ -150,4 +152,7 @@
       "getColumnDefinition": getColumnDefinition
     });
   }
-})(jQuery);
+
+  return CheckboxSelectColumn;
+
+}));

--- a/plugins/slick.headerbuttons.js
+++ b/plugins/slick.headerbuttons.js
@@ -1,13 +1,14 @@
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "Plugins": {
-        "HeaderButtons": HeaderButtons
-      }
-    }
-  });
-
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery', '../slick.core'], factory);
+  } else {
+    // Browser globals
+    root.Slick.Plugins = root.Slick.Plugins || {};
+    root.Slick.Plugins.HeaderButtons = factory(root.jQuery, root.Slick);
+  }
+}(this, function ($, Slick) {
 
   /***
    * A plugin to add custom buttons to column headers.
@@ -174,4 +175,7 @@
       "onCommand": new Slick.Event()
     });
   }
-})(jQuery);
+
+  return HeaderButtons;
+
+}));

--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -1,13 +1,14 @@
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "Plugins": {
-        "HeaderMenu": HeaderMenu
-      }
-    }
-  });
-
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery', '../slick.core'], factory);
+  } else {
+    // Browser globals
+    root.Slick.Plugins = root.Slick.Plugins || {};
+    root.Slick.Plugins.HeaderMenu = factory(root.jQuery, root.Slick);
+  }
+}(this, function ($, Slick) {
 
   /***
    * A plugin to add drop-down menus to column headers.
@@ -269,4 +270,7 @@
       "onCommand": new Slick.Event()
     });
   }
-})(jQuery);
+
+  return HeaderMenu;
+
+}));

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -1,10 +1,13 @@
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "RowMoveManager": RowMoveManager
-    }
-  });
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery', '../slick.core'], factory);
+  } else {
+    // Browser globals
+    root.Slick.RowMoveManager = factory(root.jQuery, root.Slick);
+  }
+}(this, function ($, Slick) {
 
   function RowMoveManager() {
     var _grid;
@@ -126,4 +129,7 @@
       "destroy": destroy
     });
   }
-})(jQuery);
+
+  return RowMoveManager;
+
+}));

--- a/plugins/slick.rowselectionmodel.js
+++ b/plugins/slick.rowselectionmodel.js
@@ -1,10 +1,13 @@
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "RowSelectionModel": RowSelectionModel
-    }
-  });
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery', '../slick.core'], factory);
+  } else {
+    // Browser globals
+    root.Slick.RowSelectionModel = factory(root.jQuery, root.Slick);
+  }
+}(this, function ($, Slick) {
 
   function RowSelectionModel(options) {
     var _grid;
@@ -184,4 +187,7 @@
       "onSelectedRangesChanged": new Slick.Event()
     });
   }
-})(jQuery);
+
+  return RowSelectionModel;
+
+}));

--- a/slick.core.js
+++ b/slick.core.js
@@ -4,28 +4,36 @@
  * @namespace Slick
  */
 
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "Event": Event,
-      "EventData": EventData,
-      "EventHandler": EventHandler,
-      "Range": Range,
-      "NonDataRow": NonDataItem,
-      "Group": Group,
-      "GroupTotals": GroupTotals,
-      "EditorLock": EditorLock,
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(factory);
+  } else {
+    // Browser globals
+    root.Slick = factory();
+  }
+}(this, function () {
 
-      /***
-       * A global singleton editor lock.
-       * @class GlobalEditorLock
-       * @static
-       * @constructor
-       */
-      "GlobalEditorLock": new EditorLock()
-    }
-  });
+  // register namespace
+  var Slick = {
+    "Event": Event,
+    "EventData": EventData,
+    "EventHandler": EventHandler,
+    "Range": Range,
+    "NonDataRow": NonDataItem,
+    "Group": Group,
+    "GroupTotals": GroupTotals,
+    "EditorLock": EditorLock,
+
+    /***
+     * A global singleton editor lock.
+     * @class GlobalEditorLock
+     * @static
+     * @constructor
+     */
+    "GlobalEditorLock": new EditorLock()
+  };
 
   /***
    * An event object for passing data to event handlers and letting them control propagation.
@@ -425,6 +433,7 @@
       return (activeEditController ? activeEditController.cancelCurrentEdit() : true);
     };
   }
-})(jQuery);
 
+  return Slick;
 
+}));

--- a/slick.dataview.aggregators.js
+++ b/slick.dataview.aggregators.js
@@ -1,0 +1,121 @@
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(factory);
+  } else {
+    // Browser globals
+    root.Slick.Data = root.Slick.Data || {};
+    root.Slick.Data.Aggregators = factory();
+  }
+}(this, function () {
+
+  function AvgAggregator(field) {
+    this.field_ = field;
+
+    this.init = function () {
+      this.count_ = 0;
+      this.nonNullCount_ = 0;
+      this.sum_ = 0;
+    };
+
+    this.accumulate = function (item) {
+      var val = item[this.field_];
+      this.count_ ++;
+      if (val != null && val != "" && val != NaN) {
+        this.nonNullCount_ ++;
+        this.sum_ += parseFloat(val);
+      }
+    };
+
+    this.storeResult = function (groupTotals) {
+      if (! groupTotals.avg) {
+        groupTotals.avg = {};
+      }
+      if (this.nonNullCount_ != 0) {
+        groupTotals.avg[this.field_] = this.sum_ / this.nonNullCount_;
+      }
+    };
+  }
+
+  function MinAggregator(field) {
+    this.field_ = field;
+
+    this.init = function () {
+      this.min_ = null;
+    };
+
+    this.accumulate = function (item) {
+      var val = item[this.field_];
+      if (val != null && val != "" && val != NaN) {
+        if (this.min_ == null || val < this.min_) {
+          this.min_ = val;
+        }
+      }
+    };
+
+    this.storeResult = function (groupTotals) {
+      if (! groupTotals.min) {
+        groupTotals.min = {};
+      }
+      groupTotals.min[this.field_] = this.min_;
+    }
+  }
+
+  function MaxAggregator(field) {
+    this.field_ = field;
+
+    this.init = function () {
+      this.max_ = null;
+    };
+
+    this.accumulate = function (item) {
+      var val = item[this.field_];
+      if (val != null && val != "" && val != NaN) {
+        if (this.max_ == null || val > this.max_) {
+          this.max_ = val;
+        }
+      }
+    };
+
+    this.storeResult = function (groupTotals) {
+      if (! groupTotals.max) {
+        groupTotals.max = {};
+      }
+      groupTotals.max[this.field_] = this.max_;
+    }
+  }
+
+  function SumAggregator(field) {
+    this.field_ = field;
+
+    this.init = function () {
+      this.sum_ = null;
+    };
+
+    this.accumulate = function (item) {
+      var val = item[this.field_];
+      if (val != null && val != "" && val != NaN) {
+        this.sum_ += parseFloat(val);
+      }
+    };
+
+    this.storeResult = function (groupTotals) {
+      if (! groupTotals.sum) {
+        groupTotals.sum = {};
+      }
+      groupTotals.sum[this.field_] = this.sum_;
+    }
+  }
+
+  // TODO:  add more built-in aggregators
+  // TODO:  merge common aggregators in one to prevent needles iterating
+
+  return {
+    Avg: AvgAggregator,
+    Min: MinAggregator,
+    Max: MaxAggregator,
+    Sum: SumAggregator
+  };
+
+}));

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -1,18 +1,14 @@
-(function ($) {
-  $.extend(true, window, {
-    Slick: {
-      Data: {
-        DataView: DataView,
-        Aggregators: {
-          Avg: AvgAggregator,
-          Min: MinAggregator,
-          Max: MaxAggregator,
-          Sum: SumAggregator
-        }
-      }
-    }
-  });
-
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery', './slick.core', './slick.groupitemmetadataprovider'], factory);
+  } else {
+    // Browser globals
+    root.Slick.Data = root.Slick.Data || {};
+    root.Slick.Data.DataView = factory(root.jQuery, root.Slick, root.Slick.Data.GroupItemMetadataProvider);
+  }
+}(this, function ($, Slick, GroupItemMetadataProvider) {
 
   /***
    * A sample Model implementation.
@@ -209,7 +205,7 @@
 
     function groupBy(valueGetter, valueFormatter, sortComparer) {
       if (!options.groupItemMetadataProvider) {
-        options.groupItemMetadataProvider = new Slick.Data.GroupItemMetadataProvider();
+        options.groupItemMetadataProvider = new GroupItemMetadataProvider();
       }
 
       groupingGetter = valueGetter;
@@ -805,105 +801,6 @@
     };
   }
 
-  function AvgAggregator(field) {
-    this.field_ = field;
+  return DataView;
 
-    this.init = function () {
-      this.count_ = 0;
-      this.nonNullCount_ = 0;
-      this.sum_ = 0;
-    };
-
-    this.accumulate = function (item) {
-      var val = item[this.field_];
-      this.count_++;
-      if (val != null && val != "" && val != NaN) {
-        this.nonNullCount_++;
-        this.sum_ += parseFloat(val);
-      }
-    };
-
-    this.storeResult = function (groupTotals) {
-      if (!groupTotals.avg) {
-        groupTotals.avg = {};
-      }
-      if (this.nonNullCount_ != 0) {
-        groupTotals.avg[this.field_] = this.sum_ / this.nonNullCount_;
-      }
-    };
-  }
-
-  function MinAggregator(field) {
-    this.field_ = field;
-
-    this.init = function () {
-      this.min_ = null;
-    };
-
-    this.accumulate = function (item) {
-      var val = item[this.field_];
-      if (val != null && val != "" && val != NaN) {
-        if (this.min_ == null || val < this.min_) {
-          this.min_ = val;
-        }
-      }
-    };
-
-    this.storeResult = function (groupTotals) {
-      if (!groupTotals.min) {
-        groupTotals.min = {};
-      }
-      groupTotals.min[this.field_] = this.min_;
-    }
-  }
-
-  function MaxAggregator(field) {
-    this.field_ = field;
-
-    this.init = function () {
-      this.max_ = null;
-    };
-
-    this.accumulate = function (item) {
-      var val = item[this.field_];
-      if (val != null && val != "" && val != NaN) {
-        if (this.max_ == null || val > this.max_) {
-          this.max_ = val;
-        }
-      }
-    };
-
-    this.storeResult = function (groupTotals) {
-      if (!groupTotals.max) {
-        groupTotals.max = {};
-      }
-      groupTotals.max[this.field_] = this.max_;
-    }
-  }
-
-  function SumAggregator(field) {
-    this.field_ = field;
-
-    this.init = function () {
-      this.sum_ = null;
-    };
-
-    this.accumulate = function (item) {
-      var val = item[this.field_];
-      if (val != null && val != "" && val != NaN) {
-        this.sum_ += parseFloat(val);
-      }
-    };
-
-    this.storeResult = function (groupTotals) {
-      if (!groupTotals.sum) {
-        groupTotals.sum = {};
-      }
-      groupTotals.sum[this.field_] = this.sum_;
-    }
-  }
-
-  // TODO:  add more built-in aggregators
-  // TODO:  merge common aggregators in one to prevent needles iterating
-
-})(jQuery);
+}));

--- a/slick.editors.js
+++ b/slick.editors.js
@@ -4,21 +4,16 @@
  * @namespace Slick
  */
 
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "Editors": {
-        "Text": TextEditor,
-        "Integer": IntegerEditor,
-        "Date": DateEditor,
-        "YesNoSelect": YesNoSelectEditor,
-        "Checkbox": CheckboxEditor,
-        "PercentComplete": PercentCompleteEditor,
-        "LongText": LongTextEditor
-      }
-    }
-  });
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else {
+    // Browser globals
+    root.Slick.Editors = factory(root.jQuery);
+  }
+}(this, function ($) {
 
   function TextEditor(args) {
     var $input;
@@ -509,4 +504,15 @@
 
     this.init();
   }
-})(jQuery);
+
+  return {
+    "Text": TextEditor,
+    "Integer": IntegerEditor,
+    "Date": DateEditor,
+    "YesNoSelect": YesNoSelectEditor,
+    "Checkbox": CheckboxEditor,
+    "PercentComplete": PercentCompleteEditor,
+    "LongText": LongTextEditor
+  };
+
+}));

--- a/slick.formatters.js
+++ b/slick.formatters.js
@@ -4,18 +4,16 @@
  * @namespace Slick
  */
 
-(function ($) {
-  // register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "Formatters": {
-        "PercentComplete": PercentCompleteFormatter,
-        "PercentCompleteBar": PercentCompleteBarFormatter,
-        "YesNo": YesNoFormatter,
-        "Checkmark": CheckmarkFormatter
-      }
-    }
-  });
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(factory);
+  } else {
+    // Browser globals
+    root.Slick.Formatters = factory();
+  }
+}(this, function () {
 
   function PercentCompleteFormatter(row, cell, value, columnDef, dataContext) {
     if (value == null || value === "") {
@@ -52,4 +50,12 @@
   function CheckmarkFormatter(row, cell, value, columnDef, dataContext) {
     return value ? "<img src='../images/tick.png'>" : "";
   }
-})(jQuery);
+
+  return {
+    "PercentComplete": PercentCompleteFormatter,
+    "PercentCompleteBar": PercentCompleteBarFormatter,
+    "YesNo": YesNoFormatter,
+    "Checkmark": CheckmarkFormatter
+  };
+
+}));

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -16,25 +16,27 @@
  *     and do proper cleanup.
  */
 
-// make sure required JavaScript modules are loaded
-if (typeof jQuery === "undefined") {
-  throw "SlickGrid requires jquery module to be loaded";
-}
-if (!jQuery.fn.drag) {
-  throw "SlickGrid requires jquery.event.drag module to be loaded";
-}
-if (typeof Slick === "undefined") {
-  throw "slick.core.js not loaded";
-}
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery', './slick.core', 'jquery.event/drag'], factory);
+  } else {
+    // Browser globals
+    root.Slick.Grid = factory(root.jQuery, root.Slick);
+  }
+}(this, function ($, Slick) {
 
-
-(function ($) {
-  // Slick.Grid
-  $.extend(true, window, {
-    Slick: {
-      Grid: SlickGrid
-    }
-  });
+  // make sure required JavaScript modules are loaded
+  if (typeof $ === "undefined") {
+    throw "SlickGrid requires jquery module to be loaded";
+  }
+  if (!$.fn.drag) {
+    throw "SlickGrid requires jquery.event.drag module to be loaded";
+  }
+  if (typeof Slick === "undefined") {
+    throw "slick.core.js not loaded";
+  }
 
   // shared across all grids on the page
   var scrollbarDimensions;
@@ -2909,4 +2911,7 @@ if (typeof Slick === "undefined") {
 
     init();
   }
-}(jQuery));
+
+  return SlickGrid;
+
+}));

--- a/slick.groupitemmetadataprovider.js
+++ b/slick.groupitemmetadataprovider.js
@@ -1,12 +1,14 @@
-(function ($) {
-  $.extend(true, window, {
-    Slick: {
-      Data: {
-        GroupItemMetadataProvider: GroupItemMetadataProvider
-      }
-    }
-  });
-
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery', './slick.core'], factory);
+  } else {
+    // Browser globals
+    root.Slick.Data = root.Slick.Data || {};
+    root.Slick.Data.GroupItemMetadataProvider = factory(root.jQuery, root.Slick);
+  }
+}(this, function ($, Slick) {
 
   /***
    * Provides item metadata for group (Slick.Group) and totals (Slick.Totals) rows produced by the DataView.
@@ -136,4 +138,7 @@
       "getTotalsRowMetadata": getTotalsRowMetadata
     };
   }
-})(jQuery);
+
+  return GroupItemMetadataProvider;
+
+}));

--- a/slick.remotemodel.js
+++ b/slick.remotemodel.js
@@ -1,4 +1,15 @@
-(function ($) {
+// Universal module definition
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery', './slick.core'], factory);
+  } else {
+    // Browser globals
+    root.Slick.Data = root.Slick.Data || {};
+    root.Slick.Data.RemoteModel = factory(root.jQuery, root.Slick);
+  }
+}(this, function ($, Slick) {
+
   /***
    * A sample AJAX data store implementation.
    * Right now, it's hooked up to load all Apple-related Digg stories, but can
@@ -159,6 +170,6 @@
     };
   }
 
-  // Slick.Data.RemoteModel
-  $.extend(true, window, { Slick: { Data: { RemoteModel: RemoteModel }}});
-})(jQuery);
+  return RemoteModel;
+
+}));


### PR DESCRIPTION
Added support for [umdjs](https://github.com/umdjs/umd/blob/master/amdWeb.js), for package loaders that support the AMD module definition, and fallback to browser globals.
- Wrapped JS files with [umdjs](https://github.com/umdjs/umd/blob/master/amdWeb.js)
- Added precise dependencies
- Removed namespacing `window`
- Moved aggregators to `slick.dataview.aggregators.js`
