### PR TITLE
Add getUnselectedRows method

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -3135,6 +3135,27 @@ if (typeof Slick === "undefined") {
       return ranges;
     }
 
+    function getUnselectedRows() {
+      if (!selectionModel) {
+        throw "Selection model is not set";
+      }
+
+      var tmp = 0;
+      var unselectedRows = [];
+
+      for(var i = 0; i < selectedRows.length; i ++){
+        if(selectedRows[i] != tmp){
+          for(var j = tmp; j < selectedRows[i]; j++){
+            unselectedRows[unselectedRows.length] = j;
+          }
+          tmp = selectedRows[i];
+        }
+        tmp++;
+      }
+
+      return unselectedRows;
+    }
+
     function getSelectedRows() {
       if (!selectionModel) {
         throw "Selection model is not set";
@@ -3234,6 +3255,7 @@ if (typeof Slick === "undefined") {
       "setData": setData,
       "getSelectionModel": getSelectionModel,
       "setSelectionModel": setSelectionModel,
+      "getUnselectedRows": getUnselectedRows,
       "getSelectedRows": getSelectedRows,
       "setSelectedRows": setSelectedRows,
       "getContainerNode": getContainerNode,


### PR DESCRIPTION
This method returns the rows that aren't selected.

It's useful when you need to do something with rows that aren't selected.

For example if you have a "select-all" method that selects all rows and you offer bulk operations that send all the rows to the server it would send a huge set of data. You could send a flag that says 'all' and only send the rows that aren't selected.
