### PR TITLE
Avoids (minor) jQuery fragments cache leak

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -547,9 +547,10 @@ if (typeof Slick === "undefined") {
       for (var i = 0; i < columns.length; i++) {
         var m = columns[i];
 
-        var header = $("<div class='ui-state-default slick-header-column' id='" + uid + m.id + "' />")
+        var header = $("<div class='ui-state-default slick-header-column' />")
             .html("<span class='slick-column-name'>" + m.name + "</span>")
             .width(m.width - headerColumnWidthDiff)
+            .attr("id", "" + uid + m.id)
             .attr("title", m.toolTip || "")
             .data("column", m)
             .addClass(m.headerCssClass || "")


### PR DESCRIPTION
It seems that slickgrid when running in certain situations causes
unexpected growth of the jQuery fragment cache (lots of construction
and destruction of slickgrid instances within the same 'page')

I spotted this when working on some memory allocation issues in my
app, but was unable to replicate it in the provided slickgrid tests.

However, it seems that the code this patch replaces should adequately
address: http://bugs.jquery.com/ticket/11325

Signed-off-by: ciaranj ciaranj@gmail.com
