### PR TITLE
Add index.html to the examples folder

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,61 @@
+﻿<!DOCTYPE HTML>
+<html>
+<head>
+  <title>SlickGrid Examples</title>
+  <style>
+    body {
+      font-family: Helvetica, arial, freesans, clean, sans-serif;
+      font-size: 15px;
+    }
+
+    a {
+      color: #4183c4;
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    li {
+      margin-bottom: 15px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Examples</h1>
+  <div>
+    <ul>
+      <li><a href="example1-simple.html">Basic use with minimal configuration</a></li>
+      <li><a href="example2-formatters.html">Adding some formatting</a></li>
+      <li><a href="example7-events.html">Handling events</a></li>
+      <li><a href="example14-highlighting.html">Highlighting and flashing cells</a></li>
+      <li><a href="example3-editing.html">Making it editable</a></li>
+      <li><a href="example3a-compound-editors.html">Writing compound editors</a></li>
+      <li><a href="example3b-editing-with-undo.html">Implementing Undo</a></li>
+      <li><a href="example-composite-editor-item-details.html">Using a CompositeEditor to implement detached item edit form</a></li>
+      <li>(most comprehensive) <a href="example4-model.html">Using a filtered data view to drive the grid</a></li>
+      <li><a href="example5-collapsing.html">Adding tree functionality (expand/collapse) to the grid</a></li>
+      <li><a href="example6-ajax-loading.html"><span class="caps">AJAX</span>-loading data with search</a></li>
+      <li><a href="example8-alternative-display.html">Using pre-compiled micro-templates to render cells</a></li>
+      <li><a href="example9-row-reordering.html">Row selection &amp; reordering</a></li>
+      <li><a href="example10-async-post-render.html">Using background post-rendering to add graphs</a></li>
+      <li><a href="example11-autoheight.html" title="autoHeight">No vertical scrolling</a></li>
+      <li><a href="example12-fillbrowser.html">Filling the whole window</a></li>
+      <li><a href="example13-getItem-sorting.html">Sorting by an index, getItem method</a></li>
+      <li><a href="example-header-row.html">Using fixed header row for quick filters</a></li>
+      <li><a href="example-checkbox-row-select.html">Plugin:  Checkbox row selectors with CheckboxSelectColumn plugin</a></li>
+      <li><a href="example-spreadsheet.html">Spreadsheet: cell range selection, copy’n’paste and Excel-style formula editor</a></li>
+      <li><a href="example-grouping.html">Interactive grouping and aggregates</a>.</li>
+      <li><a href="example-colspan.html">Colspan</a></li>
+      <li><a href="example-optimizing-dataview.html">Optimizing DataView for 500’000 rows</a></li>
+      <li><a href="example-explicit-initialization.html">Explicit initialization</a></li>
+      <li><a href="example-multi-column-sort.html">Multi-column sorting</a></li>
+      <li><a href="example-custom-column-value-extractor.html">Using dataItemColumnValueExtractor option to specify a custom column value extractor</a></li>
+      <li><a href="example-plugin-headerbuttons.html">Plugin: Column header buttons</a></li>
+      <li><a href="example-plugin-headermenu.html">Plugin: Column header menu</a></li>
+      <li><a href="example-autotooltips.html">Plugin: Auto tooltips</a></li>
+    </ul>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
The examples index on the wiki is very useful, and there's a need for the same thing in one's local copy of SlickGrid. I've copied the content and look & feel of the wiki page, but I've added links to the rest of the examples that are not currently linked from the wiki page.
