### PR TITLE
Add option to enable zebra striping the grid in row groups of arbitrary size

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -79,6 +79,7 @@ if (typeof Slick === "undefined") {
       editorFactory: null,
       cellFlashingCssClass: "flashing",
       selectedCellCssClass: "selected",
+      rowStripeSize: 1,
       multiSelect: true,
       enableTextSelectionOnCells: false,
       dataItemColumnValueExtractor: null,
@@ -1223,6 +1224,9 @@ if (typeof Slick === "undefined") {
       if (options.enableAddRow !== args.enableAddRow) {
         invalidateRow(getDataLength());
       }
+      if (options.rowStripeSize !== args.rowStripeSize) {
+        invalidateAllRows();
+      }
 
       options = $.extend(options, args);
       validateAndEnforceOptions();
@@ -1379,10 +1383,11 @@ if (typeof Slick === "undefined") {
     function appendRowHtml(stringArray, row, range) {
       var d = getDataItem(row);
       var dataLoading = row < getDataLength() && !d;
+      var isOdd = row % (options.rowStripeSize * 2) < options.rowStripeSize;
       var rowCss = "slick-row" +
           (dataLoading ? " loading" : "") +
           (row === activeRow ? " active" : "") +
-          (row % 2 == 1 ? " odd" : " even");
+          (isOdd ? " odd" : " even");
 
       var metadata = data.getItemMetadata && data.getItemMetadata(row);
 


### PR DESCRIPTION
I've been working on several projects where I need to create zebra stripes of different sizes, in order to allow more flexible visual grouping of rows within the grid. With the current API there doesn't seem to be an efficient way to do this, as our _most_ performant solution involved iterating through all the rows on each `onScroll` event to calculate the row ID and reset classes appropriately.

Adding a `rowStripeSize` option that controls whether a given row is treated as "even" or "odd" lets us handle this use case without having to do any extra iteration. Re-using the existing `even` and `odd` CSS classes will automatically cause the zebra striping to pick up whatever styling the user has chosen.

I'm flexible on the naming of the option, or if you have a different approach for setting row styling that you think would be better I'd be interested to hear it.
