### PR TITLE
Changed jquery.event.drag-2.2 file encoding to UTF-8

### DIFF
--- a/lib/jquery.event.drag-2.2.js
+++ b/lib/jquery.event.drag-2.2.js
@@ -178,7 +178,7 @@ drag = $special.drag = {
 			case !dd.dragging && 'touchmove': 
 				event.preventDefault();
 			case !dd.dragging && 'mousemove':
-				//  drag tolerance, x² + y² = distance²
+				//  drag tolerance, xâ‰¤ + yâ‰¤ = distanceâ‰¤
 				if ( Math.pow(  event.pageX-dd.pageX, 2 ) + Math.pow(  event.pageY-dd.pageY, 2 ) < Math.pow( dd.distance, 2 ) ) 
 					break; // distance tolerance not reached
 				event.target = dd.target; // force target from "mousedown" event (fix distance issue)


### PR DESCRIPTION
I was integrating SlickGrid with Rails `4.0.0.rc1` and was having this error. 

![SlickGrid](https://dl.dropboxusercontent.com/u/2709123/slick.png)

I saved as the `jquery.event.drag-2.2.js` with UTF-8 and there's no more error.

Thanks.
