### PR TITLE
Fix issue #653

### DIFF
--- a/slick.grid.css
+++ b/slick.grid.css
@@ -44,12 +44,14 @@ classes should alter those!
 }
 
 .slick-sort-indicator {
-  display: inline-block;
+  position: absolute;
+  display: block;
   width: 8px;
   height: 5px;
   margin-left: 4px;
   margin-top: 6px;
-  float: left;
+  right: 3px;
+  top: 4px;
 }
 
 .slick-sort-indicator-desc {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -564,7 +564,7 @@ if (typeof Slick === "undefined") {
 
         if (m.sortable) {
           header.addClass("slick-header-sortable");
-          header.prepend("<span class='slick-sort-indicator' />");
+          header.append("<span class='slick-sort-indicator' />");
         }
 
         trigger(self.onHeaderCellRendered, {


### PR DESCRIPTION
Fix issue #653 by prepending the sort indicator rather than appending it. In my testing, this fixes the problem with IE7 and makes the sort indicator work consistently in all IE versions from 7 through 10, as well as current versions of Chrome, Firefox, and Safari.
