### PR TITLE
fix issue #563 IE8 throws exception at clearTextSelection() in slick.grid.js

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2456,10 +2456,10 @@ if (typeof Slick === "undefined") {
 
     function clearTextSelection() {
       if (document.selection && document.selection.empty) {
-		try {
-				//IE fails here if selected element is not in dom
-				document.selection.empty();
-            } catch (e) { }
+        try {
+          //IE fails here if selected element is not in dom
+          document.selection.empty();
+        } catch (e) { }
       } else if (window.getSelection) {
         var sel = window.getSelection();
         if (sel && sel.removeAllRanges) {


### PR DESCRIPTION
Fix issue #563 , IE8 cause error on clearTextSelection() in slick.grid.js.
I refferd this document for fix it.
https://github.com/mootools/mootools-more/commit/eba723edc4a
