### PR TITLE
Change placement of header menu so it always fits on screen horizontally

### DIFF
--- a/examples/example-plugin-headermenu.html
+++ b/examples/example-plugin-headermenu.html
@@ -58,6 +58,7 @@
 </div>
 
 <script src="../lib/jquery-1.7.min.js"></script>
+<script src="../lib/jquery-ui-1.8.16.custom.min.js"></script>
 <script src="../lib/jquery.event.drag-2.2.js"></script>
 
 <script src="../slick.core.js"></script>

--- a/plugins/slick.headermenu.js
+++ b/plugins/slick.headermenu.js
@@ -224,16 +224,11 @@
 
 
       // Position the menu.
-      var leftPos = $menuButton.offset().left,
-          docViewRight = $(window).scrollLeft() + $(window).width(),
-          menuWidth = $menu.outerWidth();
-
-      if (leftPos + menuWidth > docViewRight) {
-        leftPos -= menuWidth - $menuButton.outerWidth();
-      }
-
-      $menu
-        .offset({ top: $menuButton.offset().top + $menuButton.height(), left: leftPos });
+      $menu.position({
+        my: "left top",
+        at: "left bottom",
+        of: $(this)
+      });
 
       // Mark the header as active to keep the highlighting.
       $activeHeaderColumn = $menuButton.closest(".slick-header-column");


### PR DESCRIPTION
Fixed the problem that if the header menu is opened close to the right border of the browser screen, the menu would not fit on screen.

This patch places the menu as before it if fits, otherwise, it places it to the left of the menu button.

Steps for testing:
- Open example Plugin: Column header menu 
- Resize browser window to have its right border right next to a menu button
- Click menu button
- Menu should fit on screen
