### PR TITLE
Add in an onColumnsChanged event

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1207,6 +1207,7 @@ if (typeof Slick === "undefined") {
         applyColumnWidths();
         handleScroll();
       }
+      trigger(self.onColumnsChanged, { columns: getColumns() });
     }
 
     function getOptions() {
@@ -3206,6 +3207,7 @@ if (typeof Slick === "undefined") {
       "onAddNewRow": new Slick.Event(),
       "onValidationError": new Slick.Event(),
       "onViewportChanged": new Slick.Event(),
+      "onColumnsChanged": new Slick.Event(),
       "onColumnsReordered": new Slick.Event(),
       "onColumnsResized": new Slick.Event(),
       "onCellChange": new Slick.Event(),


### PR DESCRIPTION
When using the column picker functionality it might be useful to know
when the user has changed what columns are being displayed.
