### PR TITLE
add ability to paste copied cell(s) more than once

### DIFF
--- a/plugins/slick.cellcopymanager.js
+++ b/plugins/slick.cellcopymanager.js
@@ -11,10 +11,15 @@
     var _grid;
     var _self = this;
     var _copiedRanges;
+    var _clearCopiedSelectionOnPaste = true;
 
     function init(grid) {
       _grid = grid;
       _grid.onKeyDown.subscribe(handleKeyDown);
+    }
+    
+     function setClearCopiedSelectionOnPaste(val) {
+        _clearCopiedSelectionOnPaste = val;
     }
 
     function destroy() {
@@ -46,10 +51,12 @@
         if (e.which == 86 && (e.ctrlKey || e.metaKey)) {
           if (_copiedRanges) {
             e.preventDefault();
-            clearCopySelection();
             ranges = _grid.getSelectionModel().getSelectedRanges();
             _self.onPasteCells.notify({from: _copiedRanges, to: ranges});
-            _copiedRanges = null;
+            if (_clearCopiedSelectionOnPaste === true) {
+                clearCopySelection();
+                _copiedRanges = null;
+            }
           }
         }
       }
@@ -77,6 +84,7 @@
       "init": init,
       "destroy": destroy,
       "clearCopySelection": clearCopySelection,
+      "setClearCopiedSelectionOnPaste": setClearCopiedSelectionOnPaste,
 
       "onCopyCells": new Slick.Event(),
       "onCopyCancelled": new Slick.Event(),


### PR DESCRIPTION
we are using this plugin but some of our users found the fact that you can't paste copied cells more than once somehow unfriendly, so we thought we'd add this.