### PR TITLE
Fixed an issue where selected rows were being lost if user checks a row ...

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -496,7 +496,7 @@
           group = groups[i];
           group.groups = extractGroups(group.rows, group);
         }
-      }      
+      }
 
       groups.sort(groupingInfos[level].comparer);
 
@@ -857,7 +857,11 @@
 
       grid.onSelectedRowsChanged.subscribe(function(e, args) {
         if (inHandler) { return; }
-        selectedRowIds = self.mapRowsToIds(grid.getSelectedRows());
+        if (preserveHidden) {
+          selectedRowIds = selectedRowIds.concat(self.mapRowsToIds(grid.getSelectedRows()));
+        } else {
+          selectedRowIds = self.mapRowsToIds(grid.getSelectedRows());
+        }
       });
 
       this.onRowsChanged.subscribe(update);


### PR DESCRIPTION
...while the grid is filtered, even if preserveHidden is true.

Steps to reproduce:
1. Select a few rows in the grid
2. Apply a filter to the grid
3. Select a few more rows in the grid
4. Remove the filter, but the rows selected in step 1 are now gone
