### PR TITLE
Support the "box-sizing: border-box;" css rule for column headers

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -879,7 +879,7 @@ if (typeof Slick === "undefined") {
 
       el = $("<div class='ui-state-default slick-header-column' style='visibility:hidden'>-</div>").appendTo($headers);
       headerColumnWidthDiff = headerColumnHeightDiff = 0;
-      if (el.css("box-sizing") != "border-box") {
+      if (el.css("box-sizing") != "border-box" && el.css("-moz-box-sizing") != "border-box" && el.css("-webkit-box-sizing") != "border-box") {
         $.each(h, function (n, val) {
           headerColumnWidthDiff += parseFloat(el.css(val)) || 0;
         });
@@ -892,7 +892,7 @@ if (typeof Slick === "undefined") {
       var r = $("<div class='slick-row' />").appendTo($canvas);
       el = $("<div class='slick-cell' id='' style='visibility:hidden'>-</div>").appendTo(r);
       cellWidthDiff = cellHeightDiff = 0;
-      if (el.css("box-sizing") != "border-box") {
+      if (el.css("box-sizing") != "border-box" && el.css("-moz-box-sizing") != "border-box" && el.css("-webkit-box-sizing") != "border-box") {
         $.each(h, function (n, val) {
           cellWidthDiff += parseFloat(el.css(val)) || 0;
         });


### PR DESCRIPTION
Allows to apply a `box-sizing: border-box;` to column headers and cells while maintaining a correct alignment.
