### PR TITLE
Update createCssRules()

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -902,7 +902,7 @@ if (typeof Slick === "undefined") {
     }
 
     function createCssRules() {
-		$style = $('<style>', { type: 'text/css', rel: 'stylesheet' }).appendTo($("head"));
+      $style = $('<style>').appendTo($("head"));
 
       var rowHeight = (options.rowHeight - cellHeightDiff);
       var rules = [


### PR DESCRIPTION
In Windows Store App, dynamic contents must use createElement.
