### PR TITLE
Fix for CheckboxEditor

### DIFF
--- a/slick.editors.js
+++ b/slick.editors.js
@@ -311,7 +311,7 @@
     };
 
     this.serializeValue = function () {
-      return !!$select.prop('checked');
+      return $select.prop('checked');
     };
 
     this.applyValue = function (item, state) {


### PR DESCRIPTION
Jquery 1.6+ requires use of prop instead of attr to manipulate/retrieve checked state.
