### PR TITLE
Performance Improvement

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1592,7 +1592,6 @@ if (typeof Slick === "undefined") {
     }
 
     function updateRowCount() {
-      var dataLength = getDataLength();
       if (!initialized) { return; }
 
       var dataLengthIncludingAddNew = getDataLengthIncludingAddNew();


### PR DESCRIPTION
The getDataLength() and getDataLengthIncludingAddNew() are being called multiple times in some code path. For example, getDataLength get called 5 times when calling resizeCanvas() which didn't count the number it get called in the onRowChanged event in turn. 

In my current project, my data came from 2 different source, each time calling getDataLength, it needs to calculate the total length. Although the calculation is not a big deal, the repeated calling could hit the performance.

Do you expecting the data length to be changed if the user didn't call UpdateRowCount? If the answer is no, I think you should have dataLength private member which is updated only when UpdateRowCount was called. Everywhere else in the code should use dataLength directly.
