### PR TITLE
Allow scrollRowIntoView to optionally center the row in the viewport

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2409,8 +2409,8 @@ if (typeof Slick === "undefined") {
       }
     }
 
-    function scrollCellIntoView(row, cell, doPaging) {
-      scrollRowIntoView(row, doPaging);
+    function scrollCellIntoView(row, cell, doPaging, doCentering) {
+      scrollRowIntoView(row, doPaging, doCentering);
 
       var colspan = getColspan(row, cell);
       var left = columnPosLeft[cell],
@@ -2688,12 +2688,19 @@ if (typeof Slick === "undefined") {
       return activeCellNode;
     }
 
-    function scrollRowIntoView(row, doPaging) {
+    function scrollRowIntoView(row, doPaging, doCentering) {
+      var height = viewportH - (viewportHasHScroll ? scrollbarDimensions.height : 0);
       var rowAtTop = row * options.rowHeight;
-      var rowAtBottom = (row + 1) * options.rowHeight - viewportH + (viewportHasHScroll ? scrollbarDimensions.height : 0);
+      var rowAtBottom = (row + 1) * options.rowHeight - height;
 
+      // need to center row?
+      if (doCentering) {
+        var centerOffset = (height - options.rowHeight) / 2;
+        scrollTo(rowAtTop - centerOffset);
+        render();
+      }
       // need to page down?
-      if ((row + 1) * options.rowHeight > scrollTop + viewportH + offset) {
+      else if ((row + 1) * options.rowHeight > scrollTop + viewportH + offset) {
         scrollTo(doPaging ? rowAtTop : rowAtBottom);
         render();
       }


### PR DESCRIPTION
This is a alternative to @janek37's pull request [added scrollRowToCenter](/janek37/SlickGrid/commit/b5b99bbcb477270b866fdbc85e198de9138f601c). As mentioned [here](/mleibman/SlickGrid/pull/724#issuecomment-23353846), it adds an optional third parameter to `scrollRowIntoView` called `doCentering` which will center the row in the viewport if `true`.
