### PR TITLE
Fix of a small bug in updateCell.

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1522,7 +1522,7 @@ if (typeof Slick === "undefined") {
       if (currentEditor && activeRow === row && activeCell === cell) {
         currentEditor.loadValue(d);
       } else {
-        cellNode.innerHTML = d ? getFormatter(row, m)(row, cell, getDataItemValueForColumn(d, m), m, d) : "";
+        cellNode[0].innerHTML = d ? getFormatter(row, m)(row, cell, getDataItemValueForColumn(d, m), m, d) : "";
         invalidatePostProcessingResults(row);
       }
     }


### PR DESCRIPTION
Setting cellNode.innerHTML instead of cellNode[0].innerHTML. 

Since cellNode is a JQuery collection, the innerHTML does not change the HTML in the DOM. 
