### PR TITLE
Fix IE8 infinite onresize loop

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1580,9 +1580,11 @@ if (typeof Slick === "undefined") {
       }
 
       numVisibleRows = Math.ceil(viewportH / options.rowHeight);
-      viewportW = parseFloat($.css($container[0], "width", true));
-      if (!options.autoHeight) {
+      
+      var newViewportW = parseFloat($.css($container[0], "width", true));
+      if (!options.autoHeight && newViewportW !== viewportW) {
         $viewport.height(viewportH);
+        viewportW = newViewportW;
       }
 
       if (options.forceFitColumns) {


### PR DESCRIPTION
Check to ensure the viewport width has changed before setting the viewport height, which in certain circumstances can cause IE8 to delve into an infinite loop of onresize events.
