### PR TITLE
Added addRowClass option to grid

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1393,7 +1393,7 @@ if (typeof Slick === "undefined") {
           (dataLoading ? " loading" : "") +
           (row === activeRow ? " active" : "") +
           (row % 2 == 1 ? " odd" : " even") +
-          (d ? "" : " " + options.addRowClass);
+          (!d && options.addRowClass ? " " + options.addRowClass : "");
 
       var metadata = data.getItemMetadata && data.getItemMetadata(row);
 


### PR DESCRIPTION
When enableAddRow is true in the grid options, addRowClass can be used to set a class for the add row. This can be then be used to apply custom styling to the add row (e.g. a different look for the the record selector/handler if you have created one, etc).
