### PR TITLE
Add onRowsRendered event

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1715,8 +1715,10 @@ if (typeof Slick === "undefined") {
         if (cacheEntry.cellRenderQueue.length) {
           var lastChild = cacheEntry.rowNode.lastChild;
           while (cacheEntry.cellRenderQueue.length) {
-            var columnIdx = cacheEntry.cellRenderQueue.pop();
-            cacheEntry.cellNodesByColumnIdx[columnIdx] = lastChild;
+            if (lastChild.className.indexOf('slick-cell') >= 0) {
+              var columnIdx = cacheEntry.cellRenderQueue.pop();
+              cacheEntry.cellNodesByColumnIdx[columnIdx] = lastChild;
+            }
             lastChild = lastChild.previousSibling;
           }
         }


### PR DESCRIPTION
This change provides an event when the rows are rendered in the grid canvas.
Add the isInitialized function to expose whether the slickgrid has been initialized.
Avoid issues when managing rows that may have additional dom elements within them.
