### PR TITLE
Allow a string (name of the function) to be used as column formatter

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1355,11 +1355,16 @@ if (typeof Slick === "undefined") {
           rowMetadata.columns &&
           (rowMetadata.columns[column.id] || rowMetadata.columns[getColumnIndex(column.id)]);
 
-      return (columnOverrides && columnOverrides.formatter) ||
+      var formatterFunction = (columnOverrides && columnOverrides.formatter) ||
           (rowMetadata && rowMetadata.formatter) ||
           column.formatter ||
           (options.formatterFactory && options.formatterFactory.getFormatter(column)) ||
           options.defaultFormatter;
+  
+      if (typeof formatterFunction === 'string' && typeof window[formatterFunction] === 'function')
+          formatterFunction = window[formatterFunction];
+          
+      return formatterFunction;
     }
 
     function getEditor(row, cell) {


### PR DESCRIPTION
Allow column option "formatter" to be a string containing the name of the formatter function and lookup the function if the formatter is a string and not a function
