### PR TITLE
Add getFilterArgs method in DataView

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -92,6 +92,10 @@
       refreshHints = hints;
     }
 
+    function getFilterArgs() {
+      return filterArgs;
+    }
+
     function setFilterArgs(args) {
       filterArgs = args;
     }
@@ -938,6 +942,7 @@
       "mapRowsToIds": mapRowsToIds,
       "mapIdsToRows": mapIdsToRows,
       "setRefreshHints": setRefreshHints,
+      "getFilterArgs": getFilterArgs,
       "setFilterArgs": setFilterArgs,
       "refresh": refresh,
       "updateItem": updateItem,


### PR DESCRIPTION
Useful for combine filters easily. Example:

```
    $(grid.getHeaderRow()).on("change keyup", ":input", function(e) {
        var $this = $(this),
            columnFilters = {};

        columnFilters[$this.data("columnId")] = $.trim($this.val());
        dataView.setFilterArgs($.extend({}, dataView.getFilterArgs(), columnFilters));

        dataView.refresh();
    });
```
