### PR TITLE
Visible row count vs total row count in slick.pager.js

### DIFF
--- a/controls/slick.pager.js
+++ b/controls/slick.pager.js
@@ -133,6 +133,13 @@
       }
 
       if (pagingInfo.pageSize == 0) {
+        var totalRowsCount = dataView.getItems().length;
+        var visibleRowsCount = pagingInfo.totalRows;
+        if (visibleRowsCount < totalRowsCount) {
+          $status.text("Showing " + visibleRowsCount + " of " + totalRowsCount + " rows");
+        } else {
+          $status.text("Showing all " + totalRowsCount + " rows");
+        }
         $status.text("Showing all " + pagingInfo.totalRows + " rows");
       } else {
         $status.text("Showing page " + (pagingInfo.pageNum + 1) + " of " + pagingInfo.totalPages);


### PR DESCRIPTION
Some plugins allow you to filter the rows in SlickGrid but the status always shows "Showing all x rows". This patch will say "Showing y of x rows" if there are less visible rows than the total rows.
