### PR TITLE
Support for function as a value for cssClass

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1432,8 +1432,9 @@ if (typeof Slick === "undefined") {
 
     function appendCellHtml(stringArray, row, cell, colspan, item) {
       var m = columns[cell];
+      var cssClass = (typeof m.cssClass === 'function') ? m.cssClass(row, cell, m, item) : m.cssClass;
       var cellCss = "slick-cell l" + cell + " r" + Math.min(columns.length - 1, cell + colspan - 1) +
-          (m.cssClass ? " " + m.cssClass : "");
+          (cssClass ? " " + cssClass : "");
       if (row === activeRow && cell === activeCell) {
         cellCss += (" active");
       }


### PR DESCRIPTION
To enable dynamic class support for the cssClass column definition property, i believe it would be nice to allow the value of the property to also hold an optional function.

What do you think?
