### PR TITLE
Add handleScroll in dragend method

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -870,6 +870,7 @@ if (typeof Slick === "undefined") {
               }
               updateCanvasWidth(true);
               render();
+              handleScroll();
               trigger(self.onColumnsResized, {});
             });
       });


### PR DESCRIPTION
In example 3-editing.html, when the SlickGrid has a horizontal scroll bar, drag the scroll bar to the far right, then drag the header to the left, you will find that the grid is not aligned with the dotted line of the grid head. Add handleScroll() in dragend method for processing the bug.
