### PR TITLE
Improved infinite loop avoidance in autoSizeColumns()

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1061,7 +1061,7 @@ if (typeof Slick === "undefined") {
           shrinkLeeway -= shrinkSize;
           widths[i] -= shrinkSize;
         }
-        if (prevTotal == total) {  // avoid infinite loop
+        if (prevTotal <= total) {  // avoid infinite loop
           break;
         }
         prevTotal = total;
@@ -1084,7 +1084,7 @@ if (typeof Slick === "undefined") {
           total += growSize;
           widths[i] += growSize;
         }
-        if (prevTotal == total) {  // avoid infinite loop
+        if (prevTotal >= total) {  // avoid infinite loop
           break;
         }
         prevTotal = total;


### PR DESCRIPTION
Fixed steps in autoSizeColumns() that detects infinite loops for shrink and grow operations.  In some cases the prevTotal exceeded total (for grow) and was less than total (for shrink).  The existing check simply checked if the 2 values were equal, but not if prevTotal had gone beyond the proper bounds, resulting in an infinite loop.
