### PR TITLE
Allow item metadata to override cell CSS

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1452,8 +1452,15 @@ if (typeof Slick === "undefined") {
 
     function appendCellHtml(stringArray, row, cell, colspan, item) {
       var m = columns[cell];
+      var cssClass = m.cssClass;
+
+      var metadata = item.getItemMetadata && item.getItemMetadata(row);
+      if (metadata && metadata.columns && metadata.columns[cell]) {
+          cssClass = metadata.columns[cell].cssClass;
+      }
+
       var cellCss = "slick-cell l" + cell + " r" + Math.min(columns.length - 1, cell + colspan - 1) +
-          (m.cssClass ? " " + m.cssClass : "");
+          (cssClass ? " " + cssClass : "");
       if (row === activeRow && cell === activeCell) {
         cellCss += (" active");
       }


### PR DESCRIPTION
I have instances where controlling the css of a cell in a specific row would be useful.  The particular use case is to make certain cells in new rows have a different appearance than the default for their column.  This change would allow the getItemMetadata column cssClass definition (if it exists) to override the default column cssClass definition.
