### PR TITLE
Allow totals row to be added before or after the group items - this is u...

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -61,6 +61,7 @@
       aggregateChildGroups: false,
       collapsed: false,
       displayTotalsRow: true,
+      totalsRowBeforeItems: false,
       lazyTotalsCalculation: false
     };
     var groupingInfos = [];
@@ -594,6 +595,11 @@
         g = groups[i];
         groupedRows[gl++] = g;
 
+        var displayTotalsRow = g.totals && gi.displayTotalsRow && (!g.collapsed || gi.aggregateCollapsed);
+        if (displayTotalsRow && gi.totalsRowBeforeItems) {
+          groupedRows[gl++] = g.totals;
+        }
+
         if (!g.collapsed) {
           rows = g.groups ? flattenGroupedRows(g.groups, level + 1) : g.rows;
           for (var j = 0, jj = rows.length; j < jj; j++) {
@@ -601,7 +607,7 @@
           }
         }
 
-        if (g.totals && gi.displayTotalsRow && (!g.collapsed || gi.aggregateCollapsed)) {
+        if (displayTotalsRow && !gi.totalsRowBeforeItems) {
           groupedRows[gl++] = g.totals;
         }
       }


### PR DESCRIPTION
...seful when groups are large, so user don't need to scroll to see totals for the interesting group
