### PR TITLE
Expand flashCell to accept css name, occurrence and immediate params

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2146,7 +2146,7 @@ if (typeof Slick === "undefined") {
           }
           setTimeout(function () {
                 $cell.queue(function () {
-                  $cell.toggleClass(options.cellFlashingCssClass).dequeue();
+                  $cell.toggleClass(cssClass || options.cellFlashingCssClass).dequeue();
                   toggleCellClass(times - 1);
                 });
               },


### PR DESCRIPTION
Current flashCell function is too restricted. To be able to better indicate the changes, such as increment and decrement with separate css class names, also how many times to toggle the class, and whether to toggle it immediately, expanding the function to include more params.

Example:
.flash_inc { color: green }
.flash_dec { color: red }

if (newValue > oldValue) grid.flashCell(row, col, speed, 'flash_inc', 6, true);
else grid.flashCell(row, col, speed, 'flash_dec', 6, true);
