### PR TITLE
fixed an issue where the dataView variable was being accessed but didn't exist

### DIFF
--- a/slick.groupitemmetadataprovider.js
+++ b/slick.groupitemmetadataprovider.js
@@ -80,7 +80,7 @@
       var item = this.getDataItem(args.row);
       if (item && item instanceof Slick.Group && $(e.target).hasClass(options.toggleCssClass)) {
         var range = _grid.getRenderedRange();
-        dataView.setRefreshHints({
+        this.getData().setRefreshHints({
           ignoreDiffsBefore: range.top,
           ignoreDiffsAfter: range.bottom
         });
@@ -104,7 +104,7 @@
           var item = this.getDataItem(activeCell.row);
           if (item && item instanceof Slick.Group) {
             var range = _grid.getRenderedRange();
-            dataView.setRefreshHints({
+            this.getData().setRefreshHints({
               ignoreDiffsBefore: range.top,
               ignoreDiffsAfter: range.bottom
             });


### PR DESCRIPTION
This does not error out in this example https://github.com/mleibman/SlickGrid/blob/gh-pages/examples/example-grouping.html because dataView is defined globally at the top of the file.
