### PR TITLE
Added the option to not clear the cell that's about to be edited as clearCellBeforeEdit

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2605,7 +2605,7 @@ if (typeof Slick === "undefined") {
       $(activeCellNode).addClass("editable");
 
       // don't clear the cell if a custom editor is passed through
-      if (!editor) {
+      if (!editor && options.clearCellBeforeEdit!==false) {
         activeCellNode.innerHTML = "";
       }
 


### PR DESCRIPTION
I'm not sure about the reason for this code https://github.com/mleibman/SlickGrid/blob/master/slick.grid.js#L2609 and I could only guess that the cell is emptied just to not have the content become visible if the grid is scrolled and the editor does not manage to reposition in time. But this is causing me problems because having the content visible there is just what I need with the editor that I'm trying to use (namely that is Bootstrap Editable). I know I can disable editing for the grid and manually process click events but I'd like to stay with the established editing process.

So there probably needs to be an option to not clear the cell (or even make this the default in a future version) as it is the easiest thing that the invoked editor could do if needed. How reasonable do you think it is to have this as an option? I believe it'd be acceptable because that code is already executed conditionally if there was no editor passed as a parameter to `makeActiveCellEditable()`.

Here is a commit that makes use of the new option `clearCellBeforeEdit` which if set to false will prevent setting the cell's innerHTML to "".
