### PR TITLE
Event.notify() should not stop if e.isPropagationStopped()

### DIFF
--- a/slick.core.js
+++ b/slick.core.js
@@ -59,6 +59,7 @@
      * @method stopImmediatePropagation
      */
     this.stopImmediatePropagation = function () {
+      isPropagationStopped = true;
       isImmediatePropagationStopped = true;
     };
 
@@ -122,7 +123,7 @@
       scope = scope || this;
 
       var returnValue;
-      for (var i = 0; i < handlers.length && !(e.isPropagationStopped() || e.isImmediatePropagationStopped()); i++) {
+      for (var i = 0; i < handlers.length && !e.isImmediatePropagationStopped(); i++) {
         returnValue = handlers[i].call(scope, e, args);
       }
 


### PR DESCRIPTION
`e.stopPropagation()` should prevent an event bubbling only, but other handlers on the same element should be executed. See http://stackoverflow.com/questions/5299740/jquery-stoppropagation-vs-stopimmediatepropagation for example.
