### PR TITLE
t

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1369,18 +1369,13 @@ if (typeof Slick === "undefined") {
       return column.editor || (options.editorFactory && options.editorFactory.getEditor(column));
     }
 
-    function getDataItemValueForColumn(item, columnDef) {
-      if (options.dataItemColumnValueExtractor) {
-        return options.dataItemColumnValueExtractor(item, columnDef);
-      }
-      
-      /**
-        * Gets the value that is going to be placed into the column
-        *
-        * @param item: the object containing the row information
-        *
-        * @columnDef: the column definition
-        **/
+    /**
+      * Gets the value that is going to be placed into the column
+      *
+      * @param item: the object containing the row information
+      *
+      * @columnDef: the column definition
+      **/
     function getDataItemValueForColumn(item, columnDef) {
       if (options.dataItemColumnValueExtractor) {
         return options.dataItemColumnValueExtractor(item, columnDef);


### PR DESCRIPTION
This change is to make slickgrid able to traverse over nested objetcts. For example we could define the next columns:

var columns = [
{ id: "antal", name: "Antal", field: "num", width: 10},
{ id: "namn", name: "Artikelnamn", field: "article.name", width: 50},
{ id: "pris", name: "Totalpris", field: "article.price", width: 50}
];
