### PR TITLE
If there are only one child row in a certain group, the parent group row...

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -596,8 +596,10 @@
 
         if (!g.collapsed) {
           rows = g.groups ? flattenGroupedRows(g.groups, level + 1) : g.rows;
-          for (var j = 0, jj = rows.length; j < jj; j++) {
-            groupedRows[gl++] = rows[j];
+          if (!options.rollupSingleChildGroup || (rows && rows.length > 1)) {
+            for (var j = 0, jj = rows.length; j < jj; j++) {
+              groupedRows[gl++] = rows[j];
+            }
           }
         }
 


### PR DESCRIPTION
... can be merged with the child row to avoid duplicate information. In this case, custom aggregator and formatter is needed to format the parent row data.
