### PR TITLE
Disable Autotooltips for Cells

### DIFF
--- a/plugins/slick.autotooltips.js
+++ b/plugins/slick.autotooltips.js
@@ -1,83 +1,85 @@
 (function ($) {
-  // Register namespace
-  $.extend(true, window, {
-    "Slick": {
-      "AutoTooltips": AutoTooltips
-    }
-  });
-
-  /**
-   * AutoTooltips plugin to show/hide tooltips when columns are too narrow to fit content.
-   * @constructor
-   * @param {boolean} [options.enableForCells=true]        - Enable tooltip for grid cells
-   * @param {boolean} [options.enableForHeaderCells=false] - Enable tooltip for header cells
-   * @param {number}  [options.maxToolTipLength=null]      - The maximum length for a tooltip
-   */
-  function AutoTooltips(options) {
-    var _grid;
-    var _self = this;
-    var _defaults = {
-      enableForCells: true,
-      enableForHeaderCells: false,
-      maxToolTipLength: null
-    };
-    
-    /**
-     * Initialize plugin.
-     */
-    function init(grid) {
-      options = $.extend(true, {}, _defaults, options);
-      _grid = grid;
-      if (options.enableForCells) _grid.onMouseEnter.subscribe(handleMouseEnter);
-      if (options.enableForHeaderCells) _grid.onHeaderMouseEnter.subscribe(handleHeaderMouseEnter);
-    }
-    
-    /**
-     * Destroy plugin.
-     */
-    function destroy() {
-      if (options.enableForCells) _grid.onMouseEnter.unsubscribe(handleMouseEnter);
-      if (options.enableForHeaderCells) _grid.onHeaderMouseEnter.unsubscribe(handleHeaderMouseEnter);
-    }
-    
-    /**
-     * Handle mouse entering grid cell to add/remove tooltip.
-     * @param {jQuery.Event} e - The event
-     */
-    function handleMouseEnter(e) {
-      var cell = _grid.getCellFromEvent(e);
-      if (cell) {
-        var $node = $(_grid.getCellNode(cell.row, cell.cell));
-        var text;
-        if ($node.innerWidth() < $node[0].scrollWidth) {
-          text = $.trim($node.text());
-          if (options.maxToolTipLength && text.length > options.maxToolTipLength) {
-            text = text.substr(0, options.maxToolTipLength - 3) + "...";
-          }
-        } else {
-          text = "";
+    // Register namespace
+    $.extend(true, window, {
+        "Slick" : {
+            "AutoTooltips" : AutoTooltips
         }
-        $node.attr("title", text);
-      }
-    }
-    
-    /**
-     * Handle mouse entering header cell to add/remove tooltip.
-     * @param {jQuery.Event} e     - The event
-     * @param {object} args.column - The column definition
-     */
-    function handleHeaderMouseEnter(e, args) {
-      var column = args.column,
-          $node = $(e.target).closest(".slick-header-column");
-      if (!column.toolTip) {
-        $node.attr("title", ($node.innerWidth() < $node[0].scrollWidth) ? column.name : "");
-      }
-    }
-    
-    // Public API
-    $.extend(this, {
-      "init": init,
-      "destroy": destroy
     });
-  }
+
+    /**
+     * AutoTooltips plugin to show/hide tooltips when columns are too narrow to fit content.
+     * @constructor
+     * @param {boolean} [options.enableForCells=true]        - Enable tooltip for grid cells
+     * @param {boolean} [options.enableForHeaderCells=false] - Enable tooltip for header cells
+     * @param {number}  [options.maxToolTipLength=null]      - The maximum length for a tooltip
+     */
+    function AutoTooltips(options) {
+        var _grid;
+        var _self = this;
+        var _defaults = {
+            enableForCells : true,
+            enableForHeaderCells : false,
+            maxToolTipLength : null,
+            disableForCells : []
+        };
+
+        /**
+         * Initialize plugin.
+         */
+        function init(grid) {
+            options = $.extend(true, {}, _defaults, options);
+            _grid = grid;
+            if (options.enableForCells) _grid.onMouseEnter.subscribe(handleMouseEnter);
+            if (options.enableForHeaderCells) _grid.onHeaderMouseEnter.subscribe(handleHeaderMouseEnter);
+        }
+
+        /**
+         * Destroy plugin.
+         */
+        function destroy() {
+            if (options.enableForCells) _grid.onMouseEnter.unsubscribe(handleMouseEnter);
+            if (options.enableForHeaderCells) _grid.onHeaderMouseEnter.unsubscribe(handleHeaderMouseEnter);
+        }
+
+        /**
+         * Handle mouse entering grid cell to add/remove tooltip.
+         * @param {jQuery.Event} e - The event
+         */
+        function handleMouseEnter(e) {
+            var cell = _grid.getCellFromEvent(e);
+            var cellId =  _grid.getColumns()[cell.cell].id
+            if (cell && options.disableForCells.indexOf(cellId)<0) {
+                var $node = $(_grid.getCellNode(cell.row, cell.cell));
+                var text;
+                if ($node.innerWidth() < $node[0].scrollWidth) {
+                    text = $.trim($node.text());
+                    if (options.maxToolTipLength && text.length > options.maxToolTipLength) {
+                        text = text.substr(0, options.maxToolTipLength - 3) + "...";
+                    }
+                } else {
+                    text = "";
+                }
+                $node.attr("title", text);
+            }
+        }
+
+        /**
+         * Handle mouse entering header cell to add/remove tooltip.
+         * @param {jQuery.Event} e     - The event
+         * @param {object} args.column - The column definition
+         */
+        function handleHeaderMouseEnter(e, args) {
+            var column = args.column,
+                $node = $(e.target).closest(".slick-header-column");
+            if (!column.toolTip) {
+                $node.attr("title", ($node.innerWidth() < $node[0].scrollWidth) ? column.name : "");
+            }
+        }
+
+        // Public API
+        $.extend(this, {
+            "init" : init,
+            "destroy" : destroy
+        });
+    }
 })(jQuery);


### PR DESCRIPTION
Hello,

in our project it was necessary to disable autotooltips for specific columns.
Now you can write down your cell.id name as an option within initializing autotooltips.

The changes are in 
- _defaults
- function handlemouseenter
