### PR TITLE
Set null as the default for showHeaderRow

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -71,7 +71,7 @@ if (typeof Slick === "undefined") {
       asyncPostRenderDelay: 50,
       autoHeight: false,
       editorLock: Slick.GlobalEditorLock,
-      showHeaderRow: false,
+      showHeaderRow: null,
       headerRowHeight: 25,
       showTopPanel: false,
       topPanelHeight: 25,
@@ -584,7 +584,7 @@ if (typeof Slick === "undefined") {
           "column": m
         });
 
-        if (options.showHeaderRow) {
+        if (options.showHeaderRow!==null) {
           var headerRowCell = $("<div class='ui-state-default slick-headerrow-column l" + i + " r" + i + "'></div>")
               .data("column", m)
               .appendTo($headerRow);


### PR DESCRIPTION
 This update is to have `showHeaderRow` to default to `null` and setting it to `false` in the options to be a flag to render the header row but keep it hidden.
Currently having it `false` prevents the header row cells from being rendered and if you later call .setHeaderRowVisibility(true) you'll get an empty box with no cells in there.
