### PR TITLE
Expose getFormatter and getEditor

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1364,7 +1364,11 @@ if (typeof Slick === "undefined") {
     }
 
     function getFormatter(row, column) {
-      var rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
+      var rowMetadata;
+      if(arguments.length>1)
+      	rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
+      else	// the row parameter must be omitted
+      	column = row;
 
       // look up by id, then index
       var columnOverrides = rowMetadata &&
@@ -1379,8 +1383,12 @@ if (typeof Slick === "undefined") {
     }
 
     function getEditor(row, cell) {
+      var rowMetadata;
+      if(arguments.length>1)
+      	rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
+      else	// the row parameter must be omitted
+      	cell = row;
       var column = columns[cell];
-      var rowMetadata = data.getItemMetadata && data.getItemMetadata(row);
       var columnMetadata = rowMetadata && rowMetadata.columns;
 
       if (columnMetadata && columnMetadata[column.id] && columnMetadata[column.id].editor !== undefined) {
@@ -3408,6 +3416,9 @@ if (typeof Slick === "undefined") {
       "setCellCssStyles": setCellCssStyles,
       "removeCellCssStyles": removeCellCssStyles,
       "getCellCssStyles": getCellCssStyles,
+
+ 	  "getFormatter":getFormatter,
+	  "getEditor":getEditor,
 
       "init": finishInitialization,
       "destroy": destroy,


### PR DESCRIPTION
This will allow formatters and editors to be used outside of the grid. This is useful when for example adding a new item and the preference is to not do that inside a row in the grid but rather in a more convenient dialog box while still preserving the look of the data (through the formatter) and presenting the same editor to the user.
