### PR TITLE
Provide row and cell indexes to cell editors

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2614,6 +2614,8 @@ if (typeof Slick === "undefined") {
         gridPosition: absBox($container[0]),
         position: absBox(activeCellNode),
         container: activeCellNode,
+        row: activeRow,
+        cell: activeCell,
         column: columnDef,
         item: item || {},
         commitChanges: commitEditAndSetFocus,


### PR DESCRIPTION
I know that normally tables display the same type of data in the cells of a column but in my case it is not like that and I need to let the editor read some additional information from the metadata block for the item.
