### PR TITLE
fix NaN problem when starting with an empty data set / zero-sized grid

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1337,7 +1337,7 @@ if (typeof Slick === "undefined") {
 
       var oldOffset = offset;
 
-      page = Math.min(n - 1, Math.floor(y / ph));
+      page = Math.min(n - 1, (ph > 0)? Math.floor(y / ph) : 0);
       offset = Math.round(page * cj);
       var newScrollTop = y - offset;
 


### PR DESCRIPTION
In certain situations the variable ph has a value of zero (like when creating the grid off-screen). This leads to a NaN value in page due to division by zero, which in turn propagates in later calculations and prevents the grid from functioning correctly.
