### PR TITLE
fix for "Columnpicker control is not fully visible" #923

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -71,8 +71,8 @@
       }
 
       $menu
-          .css("top", e.pageY - 10)
-          .css("left", e.pageX - 10)
+          .css("top", Math.min(e.pageY, $(window).height() - $menu.height()) - 10)
+          .css("left", Math.min(e.pageX, $(window).width() - $menu.width()) - 10)
           .fadeIn(options.fadeSpeed);
     }
 


### PR DESCRIPTION
When positioning the menu make sure the coordinates of the bottom right corner don't exceed window size.
