### PR TITLE
Bugfix on expanding last row of a grouped view

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -761,7 +761,7 @@
 
     function getRowDiffs(rows, newRows) {
       var item, r, eitherIsNonData, diff = [];
-      var from = 0, to = newRows.length;
+      var from = 0, to = newRows.length - 1;
 
       if (refreshHints && refreshHints.ignoreDiffsBefore) {
         from = Math.max(0,
@@ -769,11 +769,11 @@
       }
 
       if (refreshHints && refreshHints.ignoreDiffsAfter) {
-        to = Math.min(newRows.length,
+        to = Math.min(newRows.length - 1,
             Math.max(0, refreshHints.ignoreDiffsAfter));
       }
 
-      for (var i = from, rl = rows.length; i < to; i++) {
+      for (var i = from, rl = rows.length; i <= to; i++) {
         if (i >= rl) {
           diff[diff.length] = i;
         } else {


### PR DESCRIPTION
When you have a grouped view, and expanding the last one there are 2 problems:
1) The last row expander style is not changed
2) Expanding another row, will duplicate the last one
