### PR TITLE
Use global Slick.Grid.columnDefaults object

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -35,6 +35,18 @@ if (typeof Slick === "undefined") {
       Grid: SlickGrid
     }
   });
+  
+  Slick.Grid.columnDefaults = {
+	  name: "",
+	  resizable: true,
+	  sortable: false,
+	  minWidth: 30,
+	  rerenderOnResize: false,
+	  headerCssClass: null,
+	  defaultSortAsc: true,
+	  focusable: true,
+	  selectable: true
+	};
 
   // shared across all grids on the page
   var scrollbarDimensions;
@@ -89,17 +101,10 @@ if (typeof Slick === "undefined") {
       addNewRowCssClass: "new-row"
     };
 
-    var columnDefaults = {
-      name: "",
-      resizable: true,
-      sortable: false,
-      minWidth: 30,
-      rerenderOnResize: false,
-      headerCssClass: null,
-      defaultSortAsc: true,
-      focusable: true,
-      selectable: true
-    };
+    var columnDefaults = $.extend({}, Slick.Grid.columnDefaults);	// clone the global defaults object. a copy is needed as it may be modified
+    /**
+     * TO-DO: eventually can also use instance defaults object
+     */
 
     // scroller
     var th;   // virtual height


### PR DESCRIPTION
This commit exposes the `columnDefaults` object globally as `Slick.Grid.columnDefaults` to allow customizing those default values by the developer.
My particular use-case was to set `minWidth` to something like at least 100px to have the data to be readable on small devices while not having to go through the many columns of many tables on many pages in the app. I use `forceFitColumns:true` and it's great for desktop screens but on mobiles I want to have a scroller and the columns to be big enough to read at least some of the text.
