### PR TITLE
Fixed checkbox in column header doesn't work when using Grouping

### DIFF
--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -51,7 +51,7 @@
       _selectedRowsLookup = lookup;
       _grid.render();
 
-      if (selectedRows.length && selectedRows.length == _grid.getDataLength()) {
+      if (selectedRows.length && selectedRows.length == _grid.getDataLengthWithoutGroup()) {
         _grid.updateColumnHeader(_options.columnId, "<input type='checkbox' checked='checked'>", _options.toolTip);
       } else {
         _grid.updateColumnHeader(_options.columnId, "<input type='checkbox'>", _options.toolTip);

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1278,6 +1278,14 @@ if (typeof Slick === "undefined") {
       }
     }
 
+    function getDataLengthWithoutGroup() {
+      if (data.getItems) {
+        return data.getItems().length;
+      } else {
+        return data.length;
+      }
+    }
+
     function getDataLengthIncludingAddNew() {
       return getDataLength() + (options.enableAddRow ? 1 : 0);
     }


### PR DESCRIPTION
When we use Grouping, checkbox in column header won't work correctly because it compares the total number of rendered rows to selected rows which never include group header rows.
