### PR TITLE
Clear the selection if there is no active cell

### DIFF
--- a/plugins/slick.rowselectionmodel.js
+++ b/plugins/slick.rowselectionmodel.js
@@ -90,8 +90,11 @@
     }
 
     function handleActiveCellChange(e, data) {
-      if (_options.selectActiveRow && data.row != null) {
-        setSelectedRanges([new Slick.Range(data.row, 0, data.row, _grid.getColumns().length - 1)]);
+      if (_options.selectActiveRow) {
+      	var range=[];
+      	if(data.row != null)
+      		range[0]=new Slick.Range(data.row, 0, data.row, _grid.getColumns().length - 1);
+        setSelectedRanges(range);
       }
     }
 


### PR DESCRIPTION
This will have RowSelectionModel to clear its selection range if there is no active cell in the grid with the "selectActiveRow" option set.
