### PR TITLE
When using multiSelect: false option, it disables SHIFT + Arrow UP/DOWN

### DIFF
--- a/plugins/slick.rowselectionmodel.js
+++ b/plugins/slick.rowselectionmodel.js
@@ -97,7 +97,7 @@
 
     function handleKeyDown(e) {
       var activeRow = _grid.getActiveCell();
-      if (activeRow && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey && (e.which == 38 || e.which == 40)) {
+      if (_grid.getOptions().multiSelect && activeRow && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey && (e.which == 38 || e.which == 40)) {
         var selectedRows = getSelectedRows();
         selectedRows.sort(function (x, y) {
           return x - y


### PR DESCRIPTION
When using the multiSelect: false option, it was possible to use the keyboard to select multiple rows. It was a bug in the key handling function: checking for multiSelect: false was missing.
