### PR TITLE
Pass along the row and cell for custom editors.

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -2617,7 +2617,9 @@ if (typeof Slick === "undefined") {
         column: columnDef,
         item: item || {},
         commitChanges: commitEditAndSetFocus,
-        cancelChanges: cancelEditAndSetFocus
+        cancelChanges: cancelEditAndSetFocus,
+        row: activeRow, // sometimes custom editor needs location context
+        cell: activeCell
       });
 
       if (item) {


### PR DESCRIPTION
Include row and cell coordinates as properties in a Custom Editor.

Sometimes you need to know where you are within a grid so that you can apply the appropriate CSS classes to your custom editor DOM element. Otherwise you may have a editor in the bottom-most row that gets clipped by the grid's container.
