### PR TITLE
fix sort order in Chrome

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -53,7 +53,7 @@
     var groupingInfoDefaults = {
       getter: null,
       formatter: null,
-      comparer: function(a, b) { return a.value - b.value; },
+      comparer: function(a, b) { return (a.value === b.value ? 0 : (a.value > b.value ? 1 : -1)); },
       predefinedValues: [],
       aggregators: [],
       aggregateEmpty: false,


### PR DESCRIPTION
Default "comparer" function was returning unreliable result in Chrome, giving consistent but wrong sort order. Results in Firefox were correct.
