### PR TITLE
Fixed an issue where the selected class is not applied to new visible columns

### DIFF
--- a/controls/slick.columnpicker.js
+++ b/controls/slick.columnpicker.js
@@ -132,6 +132,10 @@
         }
 
         grid.setColumns(visibleColumns);
+        
+        if (grid.getSelectedRows().length > 0) {
+          grid.setSelectedRows(grid.getSelectedRows());
+        }
       }
     }
 


### PR DESCRIPTION
Reproducing the issue by using ["Checkbox row select column" example](http://mleibman.github.io/SlickGrid/examples/example-checkbox-row-select.html):
1. Right click header row and unselect **A** column.
2. Select **Row 0** by clicking the checkbox before text "Row 0".
3. Right click header row and select **A** column.

The cell with text "Row 0" is not highlighted.  (See the following snapshot)

![image 1](https://cloud.githubusercontent.com/assets/4248581/4907030/dd33a2e0-645d-11e4-9fdc-46207d20b8fc.jpg)

Similar issue was reported here:
" #892 After `setColumns` selected class is not applied to new columns"
