### PR TITLE
Show autotooltip when text overflow vertically

### DIFF
--- a/plugins/slick.autotooltips.js
+++ b/plugins/slick.autotooltips.js
@@ -49,7 +49,7 @@
       if (cell) {
         var $node = $(_grid.getCellNode(cell.row, cell.cell));
         var text;
-        if ($node.innerWidth() < $node[0].scrollWidth) {
+        if ($node.innerWidth() < $node[0].scrollWidth || $node.innerHeight() < $node[0].scrollHeight) {
           text = $.trim($node.text());
           if (options.maxToolTipLength && text.length > options.maxToolTipLength) {
             text = text.substr(0, options.maxToolTipLength - 3) + "...";


### PR DESCRIPTION
I use tall grid cell (rowHeight) and for some cells I use css white-space:normal to show wrapped text. This change shows the tooltip when such wrapped text overflow the cell vertically.
