### PR TITLE
Fix default grouping comparer sort function

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -53,7 +53,7 @@
     var groupingInfoDefaults = {
       getter: null,
       formatter: null,
-      comparer: function(a, b) { return a.value - b.value; },
+      comparer: function(a, b) { return a.value > b.value ? 1 : -1; },
       predefinedValues: [],
       aggregators: [],
       aggregateEmpty: false,


### PR DESCRIPTION
In order to sort string values correctly (which is a pretty common type of field to group on, I think) I made a slight tweak to the sort function.
