### PR TITLE
Row insertion

### DIFF
--- a/examples/example-insert-row.html
+++ b/examples/example-insert-row.html
@@ -1,0 +1,91 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+  <title>SlickGrid example: Insert or delete a row</title>
+  <link rel="stylesheet" href="../slick.grid.css" type="text/css"/>
+  <link rel="stylesheet" href="../css/smoothness/jquery-ui-1.8.16.custom.css" type="text/css"/>
+  <link rel="stylesheet" href="examples.css" type="text/css"/>
+</head>
+<body>
+<table width="100%">
+  <tr>
+    <td valign="top" width="50%">
+      <div id="myGrid" style="width:600px;height:500px;"></div>
+    </td>
+    <td valign="top">
+      <h2>Demonstrates:</h2>
+      <ul>
+        <li>adding a row</li>
+      </ul>
+        <h2>View Source:</h2>
+        <ul>
+            <li><A href="https://github.com/mleibman/SlickGrid/blob/gh-pages/examples/example-insert-row.html" target="_sourcewindow"> View the source for this example on Github</a></li>
+        </ul>
+        <button id="button" onclick="addRow()">Adding a row at index 5</button>
+    </td>
+  </tr>
+</table>
+
+<script src="../lib/jquery-1.7.min.js"></script>
+<script src="../lib/jquery.event.drag-2.2.js"></script>
+
+<script src="../slick.core.js"></script>
+<script src="../slick.grid.js"></script>
+<script src="../slick.dataview.js"></script>
+
+<script>
+  var grid;
+  var dataView;
+  var columns = [
+    {id: "title", name: "Title", field: "title"},
+    {id: "duration", name: "Duration", field: "duration"},
+    {id: "%", name: "% Complete", field: "percentComplete"},
+    {id: "start", name: "Start", field: "start"},
+    {id: "finish", name: "Finish", field: "finish"},
+    {id: "effort-driven", name: "Effort Driven", field: "effortDriven"}
+  ];
+
+  var options = {
+    enableCellNavigation: true,
+    enableColumnReorder: false
+  };
+
+  $(function () {
+    var data = [];
+    for (var i = 0; i < 500; i++) {
+      data[i] = {
+        id: i,
+        title: "Task " + i,
+        duration: "5 days",
+        percentComplete: Math.round(Math.random() * 100),
+        start: "01/01/2009",
+        finish: "01/05/2009",
+        effortDriven: (i % 5 == 0)
+      };
+    }
+
+    dataView = new Slick.Data.DataView();
+    dataView.setItems(data);
+    grid = new Slick.Grid("#myGrid", dataView, columns, options);
+
+    dataView.onRowCountChanged.subscribe(function (e, args) {
+      grid.updateRowCount();
+      grid.render();
+    });
+
+    dataView.onRowsChanged.subscribe(function (e, args) {
+      grid.invalidateRows(args.rows);
+      grid.render();
+    });
+  })
+
+  function addRow() {
+    dataView.beginUpdate();
+    dataView.insertItem(5, { id: 'new5', title: "New task", duration: "Days", percentComplete: 0 });
+    dataView.endUpdate();
+  }
+
+</script>
+</body>
+</html>

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -336,13 +336,30 @@
       refresh();
     }
 
+    /**
+     * @param newRow we wish to add. Checks that newRow defines
+     *        property idProperty, and that newRow[idProperty] is
+     *        not already taken by something in the idxById map
+     */
+    function ensureIdAndThatItDoesNotExist(newRow) {
+      var id = newRow[idProperty]
+      if (id === undefined) {
+        throw "Each data element must implement a unique 'id' property";
+      }
+      if (idxById.hasOwnProperty(id)) {
+        throw "Id " + newId + " is already taken";
+      }
+    }
+
     function insertItem(insertBefore, item) {
+      ensureIdAndThatItDoesNotExist(item)
       items.splice(insertBefore, 0, item);
       updateIdxById(insertBefore);
       refresh();
     }
 
     function addItem(item) {
+      ensureIdAndThatItDoesNotExist(item)
       items.push(item);
       updateIdxById(items.length - 1);
       refresh();
@@ -512,7 +529,7 @@
           group = groups[i];
           group.groups = extractGroups(group.rows, group);
         }
-      }      
+      }
 
       groups.sort(groupingInfos[level].comparer);
 
@@ -562,7 +579,7 @@
       level = level || 0;
       var gi = groupingInfos[level];
       var groupCollapsed = gi.collapsed;
-      var toggledGroups = toggledGroupsByLevel[level];      
+      var toggledGroups = toggledGroupsByLevel[level];
       var idx = groups.length, g;
       while (idx--) {
         g = groups[idx];
@@ -584,7 +601,7 @@
         g.collapsed = groupCollapsed ^ toggledGroups[g.groupingKey];
         g.title = gi.formatter ? gi.formatter(g) : g.value;
       }
-    } 
+    }
 
     function flattenGroupedRows(groups, level) {
       level = level || 0;
@@ -901,7 +918,7 @@
           inHandler = true;
           var selectedRows = self.mapIdsToRows(selectedRowIds);
           if (!preserveHidden) {
-            setSelectedRowIds(self.mapRowsToIds(selectedRows));       
+            setSelectedRowIds(self.mapRowsToIds(selectedRows));
           }
           grid.setSelectedRows(selectedRows);
           inHandler = false;

--- a/tests/dataview/dataview.js
+++ b/tests/dataview/dataview.js
@@ -475,7 +475,7 @@ test("updating an item to pass the filter", function() {
         same(args.pageSize, 0, "pageSize arg");
         same(args.pageNum, 0, "pageNum arg");
         same(args.totalRows, 4, "totalRows arg");
-        count++;        
+        count++;
     });
     dv.updateItem(3,{id:3,val:3});
     equal(count, 3, "events fired");
@@ -696,6 +696,16 @@ test("insert at the end", function() {
     equal(dv.getLength(), 4, "rows updated");
     assertConsistency(dv);
 });
+
+test("insert with id already taken", function() {
+    var dv = new Slick.Data.DataView()
+    dv.setItems([{id:0,val:0},{id:1,val:1},{id:2,val:2}]);
+    try {
+        dv.insertItem(2, {id:2,val:1337});
+        ok(false, "exception thrown");
+    }
+    catch (ex) {}
+})
 
 module("deleteItem");
 


### PR DESCRIPTION
A few changes:
* Added example of a simple row insertion, as it took me a little while to figure it out (but perhaps I'm just slow :smile: )
* Added function `ensureIdAndThatItDoesNotExist`to `slick.dataview.js`, and call it whenever we add a new row. Without this function, many rows will be assigned to the same key in the `idxById` map (so they will overwrite each other), and `idxById` will only contain the idx of the most recently added row with that `id`. This screws other things up; e.g., upon a call to `deleteItem`, only the most recently added row with this `id` will be deleted. Better to fail loudly the first time a duplicate `id` is added, I believe.