### PR TITLE
Adds in the word 'by' in slick.grid.js notes section for better grammar ...

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -10,7 +10,7 @@
  * SlickGrid v2.2
  *
  * NOTES:
- *     Cell/row DOM manipulations are done directly bypassing jQuery's DOM manipulation methods.
+ *     Cell/row DOM manipulations are done directly by bypassing jQuery's DOM manipulation methods.
  *     This increases the speed dramatically, but can only be done safely because there are no event handlers
  *     or data associated with any cell/row DOM nodes.  Cell editors must make sure they implement .destroy()
  *     and do proper cleanup.


### PR DESCRIPTION
Fixed a small grammatical error in the Notes section of the slick.grid.js file for better readability. 