### PR TITLE
Fixes second for loop to use var i instead of var j

### DIFF
--- a/examples/example-checkbox-row-select.html
+++ b/examples/example-checkbox-row-select.html
@@ -75,11 +75,11 @@
 
     columns.push(checkboxSelector.getColumnDefinition());
 
-    for (var i = 0; i < 5; i++) {
+    for (var j = 0; j < 5; j++) {
       columns.push({
-        id: i,
-        name: String.fromCharCode("A".charCodeAt(0) + i),
-        field: i,
+        id: j,
+        name: String.fromCharCode("A".charCodeAt(0) + j),
+        field: j,
         width: 100,
         editor: Slick.Editors.Text
       });


### PR DESCRIPTION
The second for loop in this example script reinitializes the variable i. Weird looping bugs may arise later with bigger arrays. As such, I have set the second loop to start at var j.

Before:

![screen shot 2015-02-19 at 4 49 01 pm](https://cloud.githubusercontent.com/assets/7300285/6279550/bd8ba714-b857-11e4-81c1-0be0cc3c20c5.png)

After:

![screen shot 2015-02-19 at 4 48 42 pm](https://cloud.githubusercontent.com/assets/7300285/6279551/c46a1908-b857-11e4-84a8-5eb28125bcb5.png)
