### PR TITLE
Error when moving header

### DIFF
--- a/plugins/slick.autotooltips.js
+++ b/plugins/slick.autotooltips.js
@@ -69,8 +69,8 @@
     function handleHeaderMouseEnter(e, args) {
       var column = args.column,
           $node = $(e.target).closest(".slick-header-column");
-      if (!column.toolTip) {
-        $node.attr("title", ($node.innerWidth() < $node[0].scrollWidth) ? column.name : "");
+      if (column && !column.toolTip) {
+        $node.attr("title", ($node.innerWidth() < $node[0].scrollWidth) ? $("<div/>").html(column.name).text() : "");
       }
     }
     


### PR DESCRIPTION
Get an error when moving a header column and using autotooltip.
Tooltips also show html encoded string in the tooltip.