### PR TITLE
fixed error thrown when reordering columns

### DIFF
--- a/plugins/slick.autotooltips.js
+++ b/plugins/slick.autotooltips.js
@@ -69,7 +69,7 @@
     function handleHeaderMouseEnter(e, args) {
       var column = args.column,
           $node = $(e.target).closest(".slick-header-column");
-      if (!column.toolTip) {
+      if (column && !column.toolTip) {
         $node.attr("title", ($node.innerWidth() < $node[0].scrollWidth) ? column.name : "");
       }
     }


### PR DESCRIPTION
With this plugin, reordering columns will throw errors. Need to check if the `column` object is valid first.