### PR TITLE
Fix exception on column move

### DIFF
--- a/plugins/slick.autotooltips.js
+++ b/plugins/slick.autotooltips.js
@@ -69,7 +69,7 @@
     function handleHeaderMouseEnter(e, args) {
       var column = args.column,
           $node = $(e.target).closest(".slick-header-column");
-      if (!column.toolTip) {
+      if (column && !column.toolTip) {
         $node.attr("title", ($node.innerWidth() < $node[0].scrollWidth) ? column.name : "");
       }
     }


### PR DESCRIPTION
A column moving push event with undefined `column`.

Resolve #1126
