### PR TITLE
upgrade slick grid to use .width() not .css("width")

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -273,7 +273,7 @@ if (typeof Slick === "undefined") {
       if (!initialized) {
         initialized = true;
 
-        viewportW = parseFloat($.css($container[0], "width", true));
+        viewportW = parseFloat($container.width());
 
         // header columns and cells may have different padding/border skewing width calculations (box-sizing, hello?)
         // calculate the diff so we can set consistent sizes
@@ -1606,7 +1606,7 @@ if (typeof Slick === "undefined") {
       }
 
       numVisibleRows = Math.ceil(viewportH / options.rowHeight);
-      viewportW = parseFloat($.css($container[0], "width", true));
+      viewportW = parseFloat($container.width());
       if (!options.autoHeight) {
         $viewport.height(viewportH);
       }


### PR DESCRIPTION
This change is to remove unwanted horizontal scrollbar in jQuery>3.1.1 https://github.com/6pac/SlickGrid/issues/308